### PR TITLE
[config] Add planetmint section to `app.toml`

### DIFF
--- a/cmd/planetmint-god/cmd/root.go
+++ b/cmd/planetmint-god/cmd/root.go
@@ -36,10 +36,12 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
 	// this line is used by starport scaffolding # root/moduleImport
 
 	"planetmint-go/app"
 	appparams "planetmint-go/app/params"
+	planetmintconfig "planetmint-go/config"
 )
 
 // NewRootCmd creates a new root command for a Cosmos SDK application
@@ -234,6 +236,10 @@ func (a appCreator) newApp(
 ) servertypes.Application {
 	var cache sdk.MultiStorePersistentCache
 
+	// Get [planetmint] section from app.toml
+	plmntConfig := planetmintconfig.GetConfig()
+	plmntConfig.SetWatchmenConfig(appOpts.Get("planetmint"))
+
 	if cast.ToBool(appOpts.Get(server.FlagInterBlockCache)) {
 		cache = store.NewCommitKVStoreCacheManager()
 	}
@@ -344,6 +350,7 @@ func initAppConfig() (string, interface{}) {
 
 	type CustomAppConfig struct {
 		serverconfig.Config
+		PlmntConfig planetmintconfig.Config
 	}
 
 	// Optionally allow the chain developer to overwrite the SDK's default
@@ -363,10 +370,13 @@ func initAppConfig() (string, interface{}) {
 	// In simapp, we set the min gas prices to 0.
 	srvCfg.MinGasPrices = "0stake"
 
+	plmntCfg := planetmintconfig.DefaultConfig()
+
 	customAppConfig := CustomAppConfig{
-		Config: *srvCfg,
+		Config:      *srvCfg,
+		PlmntConfig: *plmntCfg,
 	}
-	customAppTemplate := serverconfig.DefaultConfigTemplate
+	customAppTemplate := serverconfig.DefaultConfigTemplate + planetmintconfig.DefaultConfigTemplate
 
 	return customAppTemplate, customAppConfig
 }

--- a/config/config.dev.json
+++ b/config/config.dev.json
@@ -1,4 +1,0 @@
-{
-	"WATCHMEN_ENDPOINT": "localhost",
-	"WATCHMEN_PORT": 7401
-}

--- a/config/config.prod.json
+++ b/config/config.prod.json
@@ -1,4 +1,0 @@
-{
-	"WATCHMEN_ENDPOINT": "localhost",
-	"WATCHMEN_PORT": 7401
-}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.2
-	github.com/tkanos/gonfig v0.0.0-20210106201359-53e13348de2f
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4
 	google.golang.org/grpc v1.55.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -960,8 +960,6 @@ github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2l
 github.com/tendermint/go-amino v0.16.0/go.mod h1:TQU0M1i/ImAo+tYpZi73AU3V/dKeCoMC9Sphe2ZwGME=
 github.com/tidwall/btree v1.6.0 h1:LDZfKfQIBHGHWSwckhXI0RPSXzlo+KYdjK7FWSqOzzg=
 github.com/tidwall/btree v1.6.0/go.mod h1:twD9XRA5jj9VUQGELzDO4HPQTNJsoWWfYEL+EUQ2cKY=
-github.com/tkanos/gonfig v0.0.0-20210106201359-53e13348de2f h1:xDFq4NVQD34ekH5UsedBSgfxsBuPU2aZf7v4t0tH2jY=
-github.com/tkanos/gonfig v0.0.0-20210106201359-53e13348de2f/go.mod h1:DaZPBuToMc2eezA9R9nDAnmS2RMwL7yEa5YD36ESQdI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=

--- a/x/machine/keeper/msg_server_attest_machine.go
+++ b/x/machine/keeper/msg_server_attest_machine.go
@@ -46,7 +46,7 @@ func validateIssuerLiquid(issuerLiquid string) bool {
 
 func (k msgServer) reissueMachine(machine *types.Machine) error {
 	conf := config.GetConfig()
-	client := osc.NewClient(conf.WATCHMEN_ENDPOINT, int(conf.WATCHMEN_PORT))
+	client := osc.NewClient(conf.WatchmenConfig.Endpoint, conf.WatchmenConfig.Port)
 	msg := osc.NewMessage("/rddl/*")
 	msg.Append(machine.Name)
 	msg.Append(machine.Ticker)


### PR DESCRIPTION
This patch extends `app.toml` and adds the following section with these default values:

```
[planetmint]
watchmen-endpoint = "localhost"
watchmen-port = 7401
```

A global singleton `plmntConfig` is introduced to save and access the values similar to how cosmos does it (see
vendor/github.com/cosmos/cosmos-sdk/types/config.go).

Different environments can be managed by changing the values in `app.toml` and restarting the daemon.

// Closes #53