### PR TITLE
Introduce Liquid network parameters

### DIFF
--- a/config/params.go
+++ b/config/params.go
@@ -4,6 +4,9 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
+// LiquidNetParams defines the network parameters for the Liquid network.
+var LiquidNetParams chaincfg.Params
+
 // PlmntNetParams defines the network parameters for the Planetmint network.
 var PlmntNetParams = chaincfg.Params{
 	Name: "planetmint",
@@ -18,6 +21,15 @@ var PlmntNetParams = chaincfg.Params{
 }
 
 func init() {
+	// Not allowed to register LiquidNetParams, because it's just another
+	// Bitcoin network with different coin type.
+	// See https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+	LiquidNetParams = chaincfg.MainNetParams
+	LiquidNetParams.Name = "liquidv1"
+	LiquidNetParams.HDCoinType = 1776
+
+	// Need to register PlmntNetParams, otherwise we get an "unknown hd
+	// private extended key bytes" error.
 	err := chaincfg.Register(&PlmntNetParams)
 	if err != nil {
 		panic(err)

--- a/testutil/keeper/asset.go
+++ b/testutil/keeper/asset.go
@@ -10,7 +10,6 @@ import (
 
 	assettestutils "planetmint-go/x/asset/testutil"
 
-	"github.com/btcsuite/btcd/chaincfg"
 	tmdb "github.com/cometbft/cometbft-db"
 	"github.com/cometbft/cometbft/libs/log"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
@@ -51,7 +50,7 @@ func AssetKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	mk := assettestutils.NewMockMachineKeeper(ctrl)
 	sk, pk := sample.KeyPair()
 	_, ppk := sample.ExtendedKeyPair(config.PlmntNetParams)
-	_, lpk := sample.ExtendedKeyPair(chaincfg.MainNetParams)
+	_, lpk := sample.ExtendedKeyPair(config.LiquidNetParams)
 	id := sample.MachineIndex(pk, ppk, lpk)
 	mk.EXPECT().GetMachineIndex(ctx, pk).Return(id, true).AnyTimes()
 	mk.EXPECT().GetMachineIndex(ctx, sk).Return(id, false).AnyTimes()

--- a/testutil/sample/sample.go
+++ b/testutil/sample/sample.go
@@ -50,7 +50,7 @@ func AccAddress() string {
 
 func Machine(name, pubKey string) machinetypes.Machine {
 	metadata := Metadata()
-	_, liquidPubKey := ExtendedKeyPair(chaincfg.MainNetParams)
+	_, liquidPubKey := ExtendedKeyPair(config.LiquidNetParams)
 	_, planetmintPubKey := ExtendedKeyPair(config.PlmntNetParams)
 	m := machinetypes.Machine{
 		Name:             name,

--- a/x/machine/keeper/msg_server_attest_machine.go
+++ b/x/machine/keeper/msg_server_attest_machine.go
@@ -28,7 +28,7 @@ func (k msgServer) AttestMachine(goCtx context.Context, msg *types.MsgAttestMach
 	if !isValidIssuerPlanetmint {
 		return nil, errors.New("invalid planetmint key")
 	}
-	isValidIssuerLiquid := validateExtendedPublicKey(msg.Machine.IssuerLiquid, chaincfg.MainNetParams)
+	isValidIssuerLiquid := validateExtendedPublicKey(msg.Machine.IssuerLiquid, config.LiquidNetParams)
 	if !isValidIssuerLiquid {
 		return nil, errors.New("invalid liquid key")
 	}


### PR DESCRIPTION
Up to know we just use the Bitcoin mainnet parameters `chaincfg.MainNetParams` for Liquid. That's okay, because we use them for creating and verifying extended private and public keys. Those only depend on `HDPrivateKeyID` and `HDPublicKeyID`, which are the same for Bitcoin and Liquid networks.

The only real difference is the `HDCoinType` used for key derivation, which we want to use in the future. So it is a good idea to introduce this value now.