### PR TITLE
[ci] golangci-lint action needs Go 1.20

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.19', '1.20' ]
+        go-version: [ '1.20', '1.21' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Error:

* module requires Go 1.20