### PR TITLE
Use globally defined keyring backend from client.toml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,6 @@ mint-address = "{{ .PlmntConfig.MintAddress }}"
 issuance-service-dir = "{{ .PlmntConfig.IssuanceServiceDir }}"
 reissuance-asset = "{{ .PlmntConfig.ReissuanceAsset }}"
 validator-address = "{{ .PlmntConfig.ReissuanceAsset }}"
-planetmint-keyring = "{{ .PlmntConfig.PlanetmintKeyring }}"
 
 `
 
@@ -48,7 +47,6 @@ type Config struct {
 	MintAddress           string `mapstructure:"mint-address" json:"mint-address"`
 	ReissuanceAsset       string `mapstructure:"reissuance-asset" json:"reissuance-asset"`
 	ValidatorAddress      string `mapstructure:"validator-address" json:"validator-address"`
-	PlanetmintKeyring     string `mapstructure:"planetmint-keyring" json:"planetmint-keyring"`
 }
 
 // cosmos-sdk wide global singleton
@@ -79,7 +77,6 @@ func DefaultConfig() *Config {
 		MintAddress:           "default",
 		ReissuanceAsset:       "asset-id-or-name",
 		ValidatorAddress:      "plmnt1w5dww335zhh98pzv783hqre355ck3u4w4hjxcx",
-		PlanetmintKeyring:     "",
 	}
 }
 

--- a/util/issue_commands.go
+++ b/util/issue_commands.go
@@ -15,16 +15,10 @@ func InitRDDLReissuanceProcess(ctx sdk.Context, proposerAddress string, tx_unsig
 	//get_last_PoPBlockHeight() // TODO: to be read form the upcoming PoP-store
 	// Construct the command
 	sending_validator_address := config.GetConfig().ValidatorAddress
-	planetmintKeyring := config.GetConfig().PlanetmintKeyring
-
-	cmdArgStr := fmt.Sprintf("planetmint-god tx dao reissue-rddl-proposal %s '%s' %s --from %s -y",
-		proposerAddress, tx_unsigned, strconv.FormatInt(blk_height, 10),
-		sending_validator_address)
-	if planetmintKeyring != "" {
-		cmdArgStr = fmt.Sprintf("%s --keyring-backend %s", cmdArgStr, planetmintKeyring)
-	}
 	fmt.Println("REISSUE: create Proposal")
-	cmd := exec.Command("bash", "-c", cmdArgStr)
+	cmd := exec.Command("planetmint-god", "tx", "dao", "reissue-rddl-proposal",
+		"--from", sending_validator_address, "-y",
+		proposerAddress, tx_unsigned, strconv.FormatInt(blk_height, 10))
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -44,16 +38,10 @@ func InitRDDLReissuanceProcess(ctx sdk.Context, proposerAddress string, tx_unsig
 func SendRDDLReissuanceResult(ctx sdk.Context, proposerAddress string, txID string, blk_height uint64) error {
 	// Construct the command
 	sending_validator_address := config.GetConfig().ValidatorAddress
-	planetmintKeyring := config.GetConfig().PlanetmintKeyring
-
-	cmdArgStr := fmt.Sprintf("planetmint-god tx dao reissue-rddl-result %s '%s' %s --from %s -y",
-		proposerAddress, txID, strconv.FormatUint(blk_height, 10),
-		sending_validator_address)
-	if planetmintKeyring != "" {
-		cmdArgStr = fmt.Sprintf("%s --keyring-backend %s", cmdArgStr, planetmintKeyring)
-	}
 	fmt.Println("REISSUE: create Result")
-	cmd := exec.Command("bash", "-c", cmdArgStr)
+	cmd := exec.Command("planetmint-god", "tx", "dao", "reissue-rddl-result",
+		"--from", sending_validator_address, "-y",
+		proposerAddress, txID, strconv.FormatUint(blk_height, 10))
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout


### PR DESCRIPTION
This partially reverts commit 1927c4d47219c428e4d12cfd9015f0137af7a030.

// Closes #142