### PR TITLE
fixed error throwing bug that lead to block creation inconsistencies

### DIFF
--- a/x/machine/keeper/msg_server_attest_machine.go
+++ b/x/machine/keeper/msg_server_attest_machine.go
@@ -56,7 +56,9 @@ func (k msgServer) AttestMachine(goCtx context.Context, msg *types.MsgAttestMach
 		util.GetAppLogger().Info(ctx, "Issuing Machine NFT")
 		err := k.issueMachineNFT(goCtx, msg.Machine)
 		if err != nil {
-			return nil, types.ErrNFTIssuanceFailed
+			util.GetAppLogger().Info(ctx, "Machine NFT issuance failed : "+err.Error())
+		} else {
+			util.GetAppLogger().Info(ctx, "Machine NFT issuance successful")
 		}
 	} else {
 		util.GetAppLogger().Info(ctx, "skipping Machine NFT issuance")

--- a/x/machine/keeper/msg_server_attest_machine.go
+++ b/x/machine/keeper/msg_server_attest_machine.go
@@ -56,7 +56,7 @@ func (k msgServer) AttestMachine(goCtx context.Context, msg *types.MsgAttestMach
 		util.GetAppLogger().Info(ctx, "Issuing Machine NFT")
 		err := k.issueMachineNFT(goCtx, msg.Machine)
 		if err != nil {
-			util.GetAppLogger().Info(ctx, "Machine NFT issuance failed : "+err.Error())
+			util.GetAppLogger().Error(ctx, "Machine NFT issuance failed : "+err.Error())
 		} else {
 			util.GetAppLogger().Info(ctx, "Machine NFT issuance successful")
 		}


### PR DESCRIPTION
* Removed error throwing within the AttestMachine method
* Added more extensive logging around that call
