### PR TITLE
fixed precsion issue within the distribution order

### DIFF
--- a/x/dao/keeper/distribution.go
+++ b/x/dao/keeper/distribution.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/store/prefix"
@@ -68,9 +67,9 @@ func ComputeDistribution(lastReissuance int64, blockHeight int64, amount uint64)
 	distribution.InvestorAddr = conf.DistributionAddrInv
 	distribution.PopAddr = conf.DistributionAddrPop
 
-	distribution.DaoAmount = strconv.FormatUint(uint64(float64(amount)*types.PercentageDao), 10)
-	distribution.InvestorAmount = strconv.FormatUint(uint64(float64(amount)*types.PercentageInvestor), 10)
-	distribution.PopAmount = strconv.FormatUint(uint64(float64(amount)*types.PercentagePop), 10)
+	distribution.DaoAmount = util.UintValueToRDDLTokenString(uint64(float64(amount) * types.PercentageDao))
+	distribution.InvestorAmount = util.UintValueToRDDLTokenString(uint64(float64(amount) * types.PercentageInvestor))
+	distribution.PopAmount = util.UintValueToRDDLTokenString(uint64(float64(amount) * types.PercentagePop))
 
 	return distribution
 }

--- a/x/dao/keeper/distribution_test.go
+++ b/x/dao/keeper/distribution_test.go
@@ -48,10 +48,10 @@ func TestDistributionOrder(t *testing.T) {
 func TestTokenDistribution(t *testing.T) {
 	t.Parallel()
 	k, ctx := keepertest.DaoKeeper(t)
-	var reissuanceValue float64 = 998.69000000
+	reissuanceValue := 998.69000000
 	reissuances := 1000
-	var Amount1stBatch float64 = 781.0
-	var Amount2ndBatch float64 = 219.0
+	Amount1stBatch := 781.0
+	Amount2ndBatch := 219.0
 	_ = createNReissuances(k, ctx, reissuances)
 	distribution, err := k.GetDistributionForReissuedTokens(ctx, 780)
 	assert.Nil(t, err)

--- a/x/dao/keeper/distribution_test.go
+++ b/x/dao/keeper/distribution_test.go
@@ -48,36 +48,37 @@ func TestDistributionOrder(t *testing.T) {
 func TestTokenDistribution(t *testing.T) {
 	t.Parallel()
 	k, ctx := keepertest.DaoKeeper(t)
-	var reissuanceValue uint64 = 99869000000
+	var reissuanceValue float64 = 998.69000000
 	reissuances := 1000
-	var Amount1stBatch uint64 = 781
-	var Amount2ndBatch uint64 = 219
+	var Amount1stBatch float64 = 781.0
+	var Amount2ndBatch float64 = 219.0
 	_ = createNReissuances(k, ctx, reissuances)
 	distribution, err := k.GetDistributionForReissuedTokens(ctx, 780)
 	assert.Nil(t, err)
-	amount1, err1 := strconv.ParseUint(distribution.DaoAmount, 10, 64)
-	amount2, err2 := strconv.ParseUint(distribution.InvestorAmount, 10, 64)
-	amount3, err3 := strconv.ParseUint(distribution.PopAmount, 10, 64)
+
+	amount1, err1 := strconv.ParseFloat(distribution.DaoAmount, 64)
+	amount2, err2 := strconv.ParseFloat(distribution.InvestorAmount, 64)
+	amount3, err3 := strconv.ParseFloat(distribution.PopAmount, 64)
 	assert.Nil(t, err1)
 	assert.Nil(t, err2)
 	assert.Nil(t, err3)
 	sum := amount1 + amount2 + amount3
 	expSum := reissuanceValue * Amount1stBatch // add the [0] of the
-	assert.Equal(t, expSum, sum)
+	assert.True(t, expSum-sum < 0.000001)
 
 	var lastDistribution types.DistributionOrder
 	lastDistribution.LastPop = 780
 	k.StoreDistributionOrder(ctx, lastDistribution)
 	lastDistribution, err0 := k.GetDistributionForReissuedTokens(ctx, 999)
 	assert.Nil(t, err0)
-	amount1, err1 = strconv.ParseUint(lastDistribution.DaoAmount, 10, 64)
-	amount2, err2 = strconv.ParseUint(lastDistribution.InvestorAmount, 10, 64)
-	amount3, err3 = strconv.ParseUint(lastDistribution.PopAmount, 10, 64)
+	amount1, err1 = strconv.ParseFloat(lastDistribution.DaoAmount, 64)
+	amount2, err2 = strconv.ParseFloat(lastDistribution.InvestorAmount, 64)
+	amount3, err3 = strconv.ParseFloat(lastDistribution.PopAmount, 64)
 	assert.Nil(t, err1)
 	assert.Nil(t, err2)
 	assert.Nil(t, err3)
 	sum = amount1 + amount2 + amount3
 	expSum = reissuanceValue * Amount2ndBatch // add the [0] of the
-	assert.Equal(t, expSum, sum)
-	assert.Equal(t, uint64(reissuances), Amount1stBatch+Amount2ndBatch)
+	assert.True(t, expSum-sum < 0.000001)
+	assert.Equal(t, float64(reissuances), Amount1stBatch+Amount2ndBatch)
 }


### PR DESCRIPTION
the previous code didn't add precision to the values. thus, the value for the distribution tx was invalid. 