### PR TITLE
[test] Check `TxResponse` on every `ExecTestCLICmd()`

### DIFF
--- a/tests/e2e/asset/suite.go
+++ b/tests/e2e/asset/suite.go
@@ -62,11 +62,8 @@ func (s *E2ETestSuite) SetupSuite() {
 	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, bank.NewSendTxCmd(), args)
 	s.Require().NoError(err)
 
-	txResponse, err := clitestutil.GetTxResponseFromOut(out)
-	s.Require().NoError(err)
-
 	s.Require().NoError(s.network.WaitForNextBlock())
-	rawLog, err := clitestutil.GetRawLogFromTxResponse(val, txResponse)
+	rawLog, err := clitestutil.GetRawLogFromTxOut(val, out)
 	s.Require().NoError(err)
 
 	assert.Contains(s.T(), rawLog, "cosmos.bank.v1beta1.MsgSend")
@@ -104,11 +101,8 @@ func (s *E2ETestSuite) SetupSuite() {
 	out, err = clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdAttestMachine(), args)
 	s.Require().NoError(err)
 
-	txResponse, err = clitestutil.GetTxResponseFromOut(out)
-	s.Require().NoError(err)
-
 	s.Require().NoError(s.network.WaitForNextBlock())
-	rawLog, err = clitestutil.GetRawLogFromTxResponse(val, txResponse)
+	rawLog, err = clitestutil.GetRawLogFromTxOut(val, out)
 	s.Require().NoError(err)
 
 	assert.Contains(s.T(), rawLog, "planetmintgo.machine.MsgAttestMachine")
@@ -155,7 +149,7 @@ func (s *E2ETestSuite) TestNotarizeAsset() {
 		s.Require().NoError(err)
 
 		s.Require().NoError(s.network.WaitForNextBlock())
-		rawLog, err := clitestutil.GetRawLogFromTxResponse(val, txResponse)
+		rawLog, err := clitestutil.GetRawLogFromTxOut(val, out)
 
 		if !tc.expectCheckTxErr {
 			s.Require().NoError(err)

--- a/tests/e2e/dao/suite.go
+++ b/tests/e2e/dao/suite.go
@@ -182,7 +182,7 @@ func (s *E2ETestSuite) TestMintToken() {
 	s.Require().Equal(int(0), int(txResponse.Code))
 
 	s.Require().NoError(s.network.WaitForNextBlock())
-	rawLog, err := clitestutil.GetRawLogFromTxResponse(val, txResponse)
+	rawLog, err := clitestutil.GetRawLogFromTxOut(val, out)
 	s.Require().NoError(err)
 
 	assert.Contains(s.T(), rawLog, "planetmintgo.dao.MsgMintToken")
@@ -222,9 +222,7 @@ func (s *E2ETestSuite) TestMintToken() {
 		string(mrJSON),
 	}
 
-	out, err = clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.CmdMintToken(), args)
-	s.Require().NoError(err)
-
+	out, _ = clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.CmdMintToken(), args)
 	txResponse, err = clitestutil.GetTxResponseFromOut(out)
 	s.Require().NoError(err)
 	s.Require().Equal(int(2), int(txResponse.Code))

--- a/tests/e2e/machine/suite.go
+++ b/tests/e2e/machine/suite.go
@@ -55,11 +55,8 @@ func (s *E2ETestSuite) SetupSuite() {
 	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, bank.NewSendTxCmd(), args)
 	s.Require().NoError(err)
 
-	txResponse, err := clitestutil.GetTxResponseFromOut(out)
-	s.Require().NoError(err)
-
 	s.Require().NoError(s.network.WaitForNextBlock())
-	rawLog, err := clitestutil.GetRawLogFromTxResponse(val, txResponse)
+	rawLog, err := clitestutil.GetRawLogFromTxOut(val, out)
 	s.Require().NoError(err)
 
 	assert.Contains(s.T(), rawLog, "cosmos.bank.v1beta1.MsgSend")
@@ -90,11 +87,8 @@ func (s *E2ETestSuite) TestAttestMachine() {
 	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdRegisterTrustAnchor(), args)
 	s.Require().NoError(err)
 
-	txResponse, err := clitestutil.GetTxResponseFromOut(out)
-	s.Require().NoError(err)
-
 	s.Require().NoError(s.network.WaitForNextBlock())
-	rawLog, err := clitestutil.GetRawLogFromTxResponse(val, txResponse)
+	rawLog, err := clitestutil.GetRawLogFromTxOut(val, out)
 	s.Require().NoError(err)
 
 	assert.Contains(s.T(), rawLog, "planetmintgo.machine.MsgRegisterTrustAnchor")
@@ -118,11 +112,8 @@ func (s *E2ETestSuite) TestAttestMachine() {
 	out, err = clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdAttestMachine(), args)
 	s.Require().NoError(err)
 
-	txResponse, err = clitestutil.GetTxResponseFromOut(out)
-	s.Require().NoError(err)
-
 	s.Require().NoError(s.network.WaitForNextBlock())
-	rawLog, err = clitestutil.GetRawLogFromTxResponse(val, txResponse)
+	rawLog, err = clitestutil.GetRawLogFromTxOut(val, out)
 	s.Require().NoError(err)
 
 	assert.Contains(s.T(), rawLog, "planetmintgo.machine.MsgAttestMachine")
@@ -157,9 +148,7 @@ func (s *E2ETestSuite) TestInvalidAttestMachine() {
 		string(machineJSON),
 	}
 
-	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdAttestMachine(), args)
-	s.Require().NoError(err)
-
+	out, _ := clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdAttestMachine(), args)
 	txResponse, err := clitestutil.GetTxResponseFromOut(out)
 	s.Require().NoError(err)
 	s.Require().Equal(int(txResponse.Code), int(4))
@@ -177,9 +166,7 @@ func (s *E2ETestSuite) TestInvalidAttestMachine() {
 		string(machineJSON),
 	}
 
-	out, err = clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdAttestMachine(), args)
-	s.Require().NoError(err)
-
+	out, _ = clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdAttestMachine(), args)
 	txResponse, err = clitestutil.GetTxResponseFromOut(out)
 	s.Require().NoError(err)
 	s.Require().Equal(int(txResponse.Code), int(3))


### PR DESCRIPTION
Just a small improvement to not forget to check the error code of the transaction and not only from the command itself.