### PR TITLE
disable gas consuming ante handlers

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -55,11 +55,9 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		NewCheckMachineDecorator(options.MachineKeeper),
 		NewCheckMintAddressDecorator(options.DaoKeeper),
 		NewCheckReissuanceDecorator(options.DaoKeeper),
-		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
 		NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),
 		ante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
 		ante.NewValidateSigCountDecorator(options.AccountKeeper),
-		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
 	}


### PR DESCRIPTION
## Description
This PR removes all gas consuming ante handlers from the application.

### Reasoning
It was previously decided that every TX no matter the size or complexity should cost `1PLMNT` in fees. This renders the Cosmos SDK gas ante handlers basically useless. TX gas and/or gas limit is only used for the following cases:
- check if TX gas limit exceeds block gas limit
- calculate `fees = gas * gas-prices` (disabled and replaced by flat fee of 1PLMNT)
- calculate if signature verification exceeds TX gas limit

## Consequences
This allows TXs to have arbitrary size without limitations. The current implementation has no mechanism in place to limit the size of transactions which opens up an attack vector where a malicious actor could spam huge messages until all validators run out of memory or space.

### Options
- Re-enable default gas/fee behavior and charge what is owed for computation and space
- Establish other TX size limiting schemes