### PR TITLE
refactor: fix casing for reissuance variable

### DIFF
--- a/app/ante/check_reissuance_decorator.go
+++ b/app/ante/check_reissuance_decorator.go
@@ -27,7 +27,7 @@ func (cmad CheckReissuanceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simu
 			MsgProposal, ok := msg.(*daotypes.MsgReissueRDDLProposal)
 			if ok {
 				util.GetAppLogger().Debug(ctx, anteHandlerTag+"received re-issuance proposal: "+MsgProposal.String())
-				isValid := cmad.dk.IsValidReIssuanceProposal(ctx, MsgProposal)
+				isValid := cmad.dk.IsValidReissuanceProposal(ctx, MsgProposal)
 				if !isValid {
 					util.GetAppLogger().Info(ctx, anteHandlerTag+"rejected re-issuance proposal")
 					return ctx, errorsmod.Wrapf(daotypes.ErrReissuanceProposal, "error during CheckTx or ReCheckTx")

--- a/app/ante/expected_keepers.go
+++ b/app/ante/expected_keepers.go
@@ -37,5 +37,5 @@ type BankKeeper interface {
 type DaoKeeper interface {
 	GetMintRequestByHash(ctx sdk.Context, hash string) (val daotypes.MintRequest, found bool)
 	GetMintAddress(ctx sdk.Context) (mintAddress string)
-	IsValidReIssuanceProposal(ctx sdk.Context, msg *daotypes.MsgReissueRDDLProposal) (isValid bool)
+	IsValidReissuanceProposal(ctx sdk.Context, msg *daotypes.MsgReissueRDDLProposal) (isValid bool)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ distribution-address-inv = "{{ .PlmntConfig.DistributionAddrInv }}"
 distribution-address-dao = "{{ .PlmntConfig.DistributionAddrDAO }}"
 distribution-address-pop = "{{ .PlmntConfig.DistributionAddrPop }}"
 distribution-epochs = {{ .PlmntConfig.DistributionEpochs }}
-re-issuance-epochs = {{ .PlmntConfig.ReIssuanceEpochs }}
+re-issuance-epochs = {{ .PlmntConfig.ReissuanceEpochs }}
 mqtt-domain = "{{ .PlmntConfig.MqttDomain }}"
 mqtt-port = {{ .PlmntConfig.MqttPort }}
 mqtt-user = "{{ .PlmntConfig.MqttUser }}"
@@ -65,7 +65,7 @@ type Config struct {
 	DistributionAddrDAO string `json:"distribution-addr-dao" mapstructure:"distribution-addr-dao"`
 	DistributionAddrPop string `json:"distribution-addr-pop" mapstructure:"distribution-addr-pop"`
 	DistributionEpochs  int    `json:"distribution-epochs"   mapstructure:"distribution-epochs"`
-	ReIssuanceEpochs    int    `json:"re-issuance-epochs"    mapstructure:"re-issuance-epochs"`
+	ReissuanceEpochs    int    `json:"reissuance-epochs"     mapstructure:"reissuance-epochs"`
 	MqttDomain          string `json:"mqtt-domain"           mapstructure:"mqtt-domain"`
 	MqttPort            int    `json:"mqtt-port"             mapstructure:"mqtt-port"`
 	MqttUser            string `json:"mqtt-user"             mapstructure:"mqtt-user"`
@@ -103,12 +103,12 @@ func DefaultConfig() *Config {
 		DistributionAddrDAO: "vjU8eMzU3JbUWZEpVANt2ePJuPWSPixgjiSj2jDMvkVVQQi2DDnZuBRVX4Ygt5YGBf5zvTWCr1ntdqYH",
 		DistributionAddrPop: "vjTvXCFSReRsZ7grdsAreRR12KuKpDw8idueQJK9Yh1BYS7ggAqgvCxCgwh13KGK6M52y37HUmvr4GdD",
 		DistributionEpochs:  17640, // CometBFT epochs of 5s equate 1 day (12*60*24) + 30 min (12*30) to wait for confirmations on the re-issuance
-		// `ReIssuanceEpochs` is a configuration parameter that determines the number of CometBFT epochs
+		// `ReissuanceEpochs` is a configuration parameter that determines the number of CometBFT epochs
 		// required for re-issuance. In the context of Planetmint, re-issuance refers to the process of
 		// issuing new tokens. This configuration parameter specifies the number of epochs (each epoch is 5
-		// seconds) that need to pass before re-issuance can occur. In this case, `ReIssuanceEpochs` is set
+		// seconds) that need to pass before re-issuance can occur. In this case, `ReissuanceEpochs` is set
 		// to 17280, which means that re-issuance can occur after 1 day (12*60*24) of epochs.
-		ReIssuanceEpochs: 17280,
+		ReissuanceEpochs: 17280,
 		MqttDomain:       "testnet-mqtt.rddl.io",
 		MqttPort:         1885,
 		MqttUser:         "user",

--- a/tests/e2e/dao/suite.go
+++ b/tests/e2e/dao/suite.go
@@ -52,7 +52,7 @@ func (s *E2ETestSuite) SetupSuite() {
 	conf := config.GetConfig()
 	conf.FeeDenom = "node0token"
 	// set epochs: make sure to start after initial height of 7
-	conf.ReIssuanceEpochs = 25
+	conf.ReissuanceEpochs = 25
 	conf.SetPlanetmintConfig(conf)
 
 	s.T().Log("setting up e2e test suite")
@@ -243,7 +243,7 @@ func (s *E2ETestSuite) TestReissuance() {
 		// 1:  block 26: sending the re-issuance result broadcast tx succeeded
 		// 2:  block 27: confirmation
 		wait = 2
-		if latestHeight%int64(conf.ReIssuanceEpochs+wait) == 0 {
+		if latestHeight%int64(conf.ReissuanceEpochs+wait) == 0 {
 			break
 		}
 	}

--- a/x/dao/abci.go
+++ b/x/dao/abci.go
@@ -33,11 +33,11 @@ func BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock, k keeper.Keeper) 
 		}
 	}
 
-	if isReIssuanceHeight(currentBlockHeight) {
-		reIssuance, err := k.CreateNextReIssuanceObject(ctx, currentBlockHeight)
+	if isReissuanceHeight(currentBlockHeight) {
+		reissuance, err := k.CreateNextReissuanceObject(ctx, currentBlockHeight)
 		if err == nil {
-			util.SendInitReissuance(ctx, hexProposerAddress, reIssuance.GetCommand(), currentBlockHeight,
-				reIssuance.GetFirstIncludedPop(), reIssuance.GetLastIncludedPop())
+			util.SendInitReissuance(ctx, hexProposerAddress, reissuance.GetCommand(), currentBlockHeight,
+				reissuance.GetFirstIncludedPop(), reissuance.GetLastIncludedPop())
 		} else {
 			util.GetAppLogger().Error(ctx, "error while computing the RDDL re-issuance ", err)
 		}
@@ -58,9 +58,9 @@ func isPopHeight(height int64) bool {
 	return height%int64(conf.PopEpochs) == 0
 }
 
-func isReIssuanceHeight(height int64) bool {
+func isReissuanceHeight(height int64) bool {
 	conf := config.GetConfig()
-	return height%int64(conf.ReIssuanceEpochs) == 0
+	return height%int64(conf.ReissuanceEpochs) == 0
 }
 
 func isDistributionHeight(height int64) bool {

--- a/x/dao/keeper/msg_server_distribution_request.go
+++ b/x/dao/keeper/msg_server_distribution_request.go
@@ -16,7 +16,7 @@ var (
 func (k msgServer) DistributionRequest(goCtx context.Context, msg *types.MsgDistributionRequest) (*types.MsgDistributionRequestResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	lastReissuance, found := k.GetLastReIssuance(ctx)
+	lastReissuance, found := k.GetLastReissuance(ctx)
 	if !found {
 		return nil, errorsmod.Wrap(types.ErrReissuanceNotFound, "for last reissuance height")
 	}

--- a/x/dao/keeper/query_reissuances_test.go
+++ b/x/dao/keeper/query_reissuances_test.go
@@ -49,7 +49,7 @@ func TestQueryReissuances(t *testing.T) {
 			responseReissuance: reissuances[1:6],
 		},
 		{
-			desc: "query 5*ReIssuanceEpochs key 0 offset 10 limit",
+			desc: "query 5*ReissuanceEpochs key 0 offset 10 limit",
 			request: &types.QueryReissuancesRequest{
 				Pagination: &query.PageRequest{
 					Key:        util.SerializeInt64(4),

--- a/x/dao/keeper/reissuance.go
+++ b/x/dao/keeper/reissuance.go
@@ -11,10 +11,10 @@ import (
 	"github.com/planetmint/planetmint-go/x/dao/types"
 )
 
-var ReIssueCommand string
+var ReissueCommand string
 
 func init() {
-	ReIssueCommand = "reissueasset"
+	ReissueCommand = "reissueasset"
 }
 
 func GetReissuanceAsStringValue(blockHeight int64) string {
@@ -38,45 +38,45 @@ func GetReissuanceAsStringValue(blockHeight int64) string {
 }
 
 func GetReissuanceCommand(assetID string, blockHeight int64) string {
-	return ReIssueCommand + " " + assetID + " " + GetReissuanceAsStringValue(blockHeight)
+	return ReissueCommand + " " + assetID + " " + GetReissuanceAsStringValue(blockHeight)
 }
 
 func IsValidReissuanceCommand(reissuanceStr string, assetID string, blockHeight int64) bool {
-	expected := ReIssueCommand + " " + assetID + " " + GetReissuanceAsStringValue(blockHeight)
+	expected := ReissueCommand + " " + assetID + " " + GetReissuanceAsStringValue(blockHeight)
 	return reissuanceStr == expected
 }
 
 func GetReissuanceCommandForValue(assetID string, value uint64) string {
-	return ReIssueCommand + " " + assetID + " " + util.UintValueToRDDLTokenString(value)
+	return ReissueCommand + " " + assetID + " " + util.UintValueToRDDLTokenString(value)
 }
 
-func (k Keeper) CreateNextReIssuanceObject(ctx sdk.Context, currentBlockHeight int64) (reIssuance types.Reissuance, err error) {
+func (k Keeper) CreateNextReissuanceObject(ctx sdk.Context, currentBlockHeight int64) (reissuance types.Reissuance, err error) {
 	var lastReissuedPop int64
-	lastReIssuance, found := k.GetLastReIssuance(ctx)
+	lastReissuance, found := k.GetLastReissuance(ctx)
 	if found {
-		lastReissuedPop = lastReIssuance.LastIncludedPop
+		lastReissuedPop = lastReissuance.LastIncludedPop
 	}
-	reIssuanceValue, firstIncludedPop, lastIncludedPop, err := k.ComputeReIssuanceValue(ctx, lastReissuedPop, currentBlockHeight)
+	reissuanceValue, firstIncludedPop, lastIncludedPop, err := k.ComputeReissuanceValue(ctx, lastReissuedPop, currentBlockHeight)
 	if err != nil {
 		return
 	}
 
-	reIssuance.Command = GetReissuanceCommandForValue(config.GetConfig().ReissuanceAsset, reIssuanceValue)
-	reIssuance.BlockHeight = currentBlockHeight
-	reIssuance.FirstIncludedPop = firstIncludedPop
-	reIssuance.LastIncludedPop = lastIncludedPop
+	reissuance.Command = GetReissuanceCommandForValue(config.GetConfig().ReissuanceAsset, reissuanceValue)
+	reissuance.BlockHeight = currentBlockHeight
+	reissuance.FirstIncludedPop = firstIncludedPop
+	reissuance.LastIncludedPop = lastIncludedPop
 	return
 }
 
-func (k Keeper) IsValidReIssuanceProposal(ctx sdk.Context, msg *types.MsgReissueRDDLProposal) (isValid bool) {
-	reIssuance, err := k.CreateNextReIssuanceObject(ctx, msg.GetBlockHeight())
+func (k Keeper) IsValidReissuanceProposal(ctx sdk.Context, msg *types.MsgReissueRDDLProposal) (isValid bool) {
+	reissuance, err := k.CreateNextReissuanceObject(ctx, msg.GetBlockHeight())
 	if err != nil {
 		return
 	}
-	if reIssuance.GetBlockHeight() == msg.GetBlockHeight() &&
-		reIssuance.GetFirstIncludedPop() == msg.GetFirstIncludedPop() &&
-		reIssuance.GetLastIncludedPop() == msg.GetLastIncludedPop() &&
-		reIssuance.GetCommand() == msg.GetCommand() &&
+	if reissuance.GetBlockHeight() == msg.GetBlockHeight() &&
+		reissuance.GetFirstIncludedPop() == msg.GetFirstIncludedPop() &&
+		reissuance.GetLastIncludedPop() == msg.GetLastIncludedPop() &&
+		reissuance.GetCommand() == msg.GetCommand() &&
 		msg.GetProposer() != "" {
 		isValid = true
 	}
@@ -114,20 +114,20 @@ func (k Keeper) getReissuancesRange(ctx sdk.Context, from int64) (reissuances []
 	return
 }
 
-func (k Keeper) GetLastReIssuance(ctx sdk.Context) (val types.Reissuance, found bool) {
+func (k Keeper) GetLastReissuance(ctx sdk.Context) (val types.Reissuance, found bool) {
 	store := prefix.NewStore(ctx.KVStore(k.storeKey), types.KeyPrefix(types.ReissuanceBlockHeightKey))
 
 	iterator := store.ReverseIterator(nil, nil)
 	defer iterator.Close()
 	found = iterator.Valid()
 	if found {
-		reIssuance := iterator.Value()
-		k.cdc.MustUnmarshal(reIssuance, &val)
+		reissuance := iterator.Value()
+		k.cdc.MustUnmarshal(reissuance, &val)
 	}
 	return val, found
 }
 
-func (k Keeper) ComputeReIssuanceValue(ctx sdk.Context, startHeight int64, endHeight int64) (reIssuanceValue uint64, firstIncludedPop int64, lastIncludedPop int64, err error) {
+func (k Keeper) ComputeReissuanceValue(ctx sdk.Context, startHeight int64, endHeight int64) (reissuanceValue uint64, firstIncludedPop int64, lastIncludedPop int64, err error) {
 	challenges, err := k.GetChallengeRange(ctx, startHeight, endHeight)
 	if err != nil {
 		util.GetAppLogger().Error(ctx, "unable to compute get challenges")
@@ -139,8 +139,8 @@ func (k Keeper) ComputeReIssuanceValue(ctx sdk.Context, startHeight int64, endHe
 		popString := fmt.Sprintf("firstPoP: %d, PoP height: %d, current height %d", startHeight, obj.GetHeight(), endHeight)
 		// if (index == 0 && startHeight == 0 && obj.BlockHeight == 0) || // corner case (beginning of the chain)
 		if startHeight < obj.GetHeight() && obj.GetHeight()+2*popEpochs <= endHeight {
-			popReIssuanceString := GetReissuanceAsStringValue(obj.GetHeight())
-			amount, err := util.RDDLTokenStringToUint(popReIssuanceString)
+			popReissuanceString := GetReissuanceAsStringValue(obj.GetHeight())
+			amount, err := util.RDDLTokenStringToUint(popReissuanceString)
 			if err != nil {
 				util.GetAppLogger().Error(ctx, "unable to compute PoP re-issuance value: "+popString)
 				continue
@@ -158,6 +158,6 @@ func (k Keeper) ComputeReIssuanceValue(ctx sdk.Context, startHeight int64, endHe
 			}
 		}
 	}
-	reIssuanceValue = overallAmount
+	reissuanceValue = overallAmount
 	return
 }

--- a/x/dao/keeper/reissuance_test.go
+++ b/x/dao/keeper/reissuance_test.go
@@ -36,7 +36,7 @@ func TestReissuanceComputation(t *testing.T) {
 	popepoch := int64(config.GetConfig().PopEpochs)
 	_ = createNChallenge(k, ctx, numChallenges)
 
-	reIssuanceValue1, firstIncludedPop, lastIncludedPop, err := k.ComputeReIssuanceValue(ctx, 0, 780*popepoch)
+	reissuanceValue1, firstIncludedPop, lastIncludedPop, err := k.ComputeReissuanceValue(ctx, 0, 780*popepoch)
 	assert.Nil(t, err)
 
 	// explaining the numbers:
@@ -46,22 +46,22 @@ func TestReissuanceComputation(t *testing.T) {
 	assert.Equal(t, indexFirst, int64(1))
 	assert.Equal(t, indexLast, int64(778))
 	expSum := reissuanceValue * uint64(indexLast-indexFirst+1) // add 1 to count for the one that is missing by subtraction
-	assert.Equal(t, expSum, reIssuanceValue1)
+	assert.Equal(t, expSum, reissuanceValue1)
 
-	var lastReIssuance types.Reissuance
-	lastReIssuance.FirstIncludedPop = firstIncludedPop
-	lastReIssuance.LastIncludedPop = lastIncludedPop
-	k.StoreReissuance(ctx, lastReIssuance)
-	lastReIssuanceValue2nd, firstIncludedPop, lastIncludedPop, err0 := k.ComputeReIssuanceValue(ctx, lastIncludedPop, 1000*int64(config.GetConfig().PopEpochs))
+	var lastReissuance types.Reissuance
+	lastReissuance.FirstIncludedPop = firstIncludedPop
+	lastReissuance.LastIncludedPop = lastIncludedPop
+	k.StoreReissuance(ctx, lastReissuance)
+	lastReissuanceValue2nd, firstIncludedPop, lastIncludedPop, err0 := k.ComputeReissuanceValue(ctx, lastIncludedPop, 1000*int64(config.GetConfig().PopEpochs))
 	assert.Nil(t, err0)
 	indexFirst2nd := firstIncludedPop / popepoch
 	indexLast2nd := lastIncludedPop / popepoch
 	assert.Equal(t, indexLast+1, indexFirst2nd)
 	assert.Equal(t, int64(numChallenges-2), indexLast2nd)
 	expSum = reissuanceValue * uint64(indexLast2nd-indexFirst2nd+1) // add the [0] of the
-	assert.Equal(t, expSum, lastReIssuanceValue2nd)
+	assert.Equal(t, expSum, lastReissuanceValue2nd)
 	expectedSum := uint64(numChallenges-2) * reissuanceValue
-	computedSum := lastReIssuanceValue2nd + reIssuanceValue1
+	computedSum := lastReissuanceValue2nd + reissuanceValue1
 	assert.Equal(t, expectedSum, computedSum)
 }
 


### PR DESCRIPTION
Reissue and reissuance are standalone words and should not contain an uppercase `I` in the variable name. This should only happen to connect different word like: file name gets `fileName` resp. `FileName`.