### PR TITLE
311 review test case ssendpopresultoutbytes true todo bug

### DIFF
--- a/tests/e2e/dao/pop_participant_selection_suite.go
+++ b/tests/e2e/dao/pop_participant_selection_suite.go
@@ -138,8 +138,16 @@ func (s *PopSelectionE2ETestSuite) sendPoPResult(storedChallenge []byte, success
 	challenge.Finished = true
 	challenge.Success = success
 
-	msg := daotypes.NewMsgReportPopResult(val.Address.String(), &challenge)
-	_, err = e2etestutil.BuildSignBroadcastTx(s.T(), val.Address, msg)
+	machineName := machines[0].name
+	if challenge.Challenger != machines[0].address {
+		machineName = machines[1].name
+	}
+	k, err := val.ClientCtx.Keyring.Key(machineName)
+	s.Require().NoError(err)
+	challengerAccAddress, _ := k.GetAddress()
+
+	msg := daotypes.NewMsgReportPopResult(challengerAccAddress.String(), &challenge)
+	_, err := e2etestutil.BuildSignBroadcastTx(s.T(), challengerAccAddress, msg)
 	s.Require().NoError(err)
 }
 
@@ -148,7 +156,6 @@ func (s *PopSelectionE2ETestSuite) TestPopSelectionNoActors() {
 
 	assert.NotContains(s.T(), out.String(), machines[0].address)
 	assert.NotContains(s.T(), out.String(), machines[1].address)
-	s.sendPoPResult(out.Bytes(), true)
 }
 
 func (s *PopSelectionE2ETestSuite) TestPopSelectionOneActors() {
@@ -159,7 +166,6 @@ func (s *PopSelectionE2ETestSuite) TestPopSelectionOneActors() {
 
 	assert.NotContains(s.T(), out.String(), machines[0].address)
 	assert.NotContains(s.T(), out.String(), machines[1].address)
-	s.sendPoPResult(out.Bytes(), true)
 }
 
 func (s *PopSelectionE2ETestSuite) TestPopSelectionTwoActors() {

--- a/tests/e2e/dao/pop_participant_selection_suite.go
+++ b/tests/e2e/dao/pop_participant_selection_suite.go
@@ -147,7 +147,7 @@ func (s *PopSelectionE2ETestSuite) sendPoPResult(storedChallenge []byte, success
 	challengerAccAddress, _ := k.GetAddress()
 
 	msg := daotypes.NewMsgReportPopResult(challengerAccAddress.String(), &challenge)
-	_, err := e2etestutil.BuildSignBroadcastTx(s.T(), challengerAccAddress, msg)
+	_, err = e2etestutil.BuildSignBroadcastTx(s.T(), challengerAccAddress, msg)
 	s.Require().NoError(err)
 }
 

--- a/x/dao/types/errors.go
+++ b/x/dao/types/errors.go
@@ -28,4 +28,5 @@ var (
 	ErrDistributionWrongHeight  = errorsmod.Register(ModuleName, 19, "distribution wrong height")
 	ErrConvertClaims            = errorsmod.Register(ModuleName, 20, "convert claim failed")
 	ErrInvalidClaimAddress      = errorsmod.Register(ModuleName, 21, "invalid claim address")
+	ErrInvalidPopReporter       = errorsmod.Register(ModuleName, 22, "invalid PoP reporter")
 )


### PR DESCRIPTION
reviewed PoPSelection testSuite. 
The test criteria weren't changed. However, the PoPReport became more restrictive to avoid any hijacking of PoP challenges and potential fraud. 

most important change: the PoPResult reporter/sender has to be the challenger. 