### PR TITLE
Eckelj/reducing code smell

### DIFF
--- a/app/ante/check_machine_decorator.go
+++ b/app/ante/check_machine_decorator.go
@@ -51,21 +51,21 @@ func (cm CheckMachineDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate 
 func (cm CheckMachineDecorator) handleNotarizeAsset(ctx sdk.Context, notarizeMsg *assettypes.MsgNotarizeAsset) (sdk.Context, error) {
 	_, found := cm.mk.GetMachineIndexByAddress(ctx, notarizeMsg.GetCreator())
 	if !found {
-		return ctx, errorsmod.Wrapf(machinetypes.ErrMachineNotFound, "error during CheckTx or ReCheckTx")
+		return ctx, errorsmod.Wrapf(machinetypes.ErrMachineNotFound, ErrorAnteContext)
 	}
 	return ctx, nil
 }
 
 func (cm CheckMachineDecorator) handleAttestMachine(ctx sdk.Context, attestMsg *machinetypes.MsgAttestMachine) (sdk.Context, error) {
 	if attestMsg.GetCreator() != attestMsg.Machine.GetAddress() {
-		return ctx, errorsmod.Wrapf(machinetypes.ErrMachineIsNotCreator, "error during CheckTx or ReCheckTx")
+		return ctx, errorsmod.Wrapf(machinetypes.ErrMachineIsNotCreator, ErrorAnteContext)
 	}
 	_, activated, found := cm.mk.GetTrustAnchor(ctx, attestMsg.Machine.MachineId)
 	if !found {
-		return ctx, errorsmod.Wrapf(machinetypes.ErrTrustAnchorNotFound, "error during CheckTx or ReCheckTx")
+		return ctx, errorsmod.Wrapf(machinetypes.ErrTrustAnchorNotFound, ErrorAnteContext)
 	}
 	if activated {
-		return ctx, errorsmod.Wrapf(machinetypes.ErrTrustAnchorAlreadyInUse, "error during CheckTx or ReCheckTx")
+		return ctx, errorsmod.Wrapf(machinetypes.ErrTrustAnchorAlreadyInUse, ErrorAnteContext)
 	}
 	return ctx, nil
 }
@@ -73,7 +73,7 @@ func (cm CheckMachineDecorator) handleAttestMachine(ctx sdk.Context, attestMsg *
 func (cm CheckMachineDecorator) handlePopResult(ctx sdk.Context, popMsg *daotypes.MsgReportPopResult) (sdk.Context, error) {
 	_, found := cm.mk.GetMachineIndexByAddress(ctx, popMsg.GetCreator())
 	if !found {
-		return ctx, errorsmod.Wrapf(machinetypes.ErrMachineNotFound, "error during CheckTx or ReCheckTx")
+		return ctx, errorsmod.Wrapf(machinetypes.ErrMachineNotFound, ErrorAnteContext)
 	}
 	return ctx, nil
 }

--- a/app/ante/check_reissuance_decorator.go
+++ b/app/ante/check_reissuance_decorator.go
@@ -30,7 +30,7 @@ func (cmad CheckReissuanceDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simu
 				isValid := cmad.dk.IsValidReissuanceProposal(ctx, MsgProposal)
 				if !isValid {
 					util.GetAppLogger().Info(ctx, anteHandlerTag+"rejected reissuance proposal")
-					return ctx, errorsmod.Wrapf(daotypes.ErrReissuanceProposal, "error during CheckTx or ReCheckTx")
+					return ctx, errorsmod.Wrapf(daotypes.ErrReissuanceProposal, ErrorAnteContext)
 				}
 				util.GetAppLogger().Debug(ctx, anteHandlerTag+"accepted reissuance proposal: "+MsgProposal.String())
 			}

--- a/app/ante/check_validator_decorator.go
+++ b/app/ante/check_validator_decorator.go
@@ -53,7 +53,7 @@ func (cv CheckValidatorDecorator) handleMsg(ctx sdk.Context, msg sdk.Msg) (_ sdk
 	signer := msg.GetSigners()[0]
 	_, found := cv.sk.GetValidator(ctx, sdk.ValAddress(signer))
 	if !found {
-		return ctx, errorsmod.Wrapf(types.ErrRestrictedMsg, "error during CheckTx or ReCheckTx")
+		return ctx, errorsmod.Wrapf(types.ErrRestrictedMsg, ErrorAnteContext)
 	}
 	return ctx, nil
 }

--- a/app/ante/deduct_fee_decorator.go
+++ b/app/ante/deduct_fee_decorator.go
@@ -40,7 +40,7 @@ func NewDeductFeeDecorator(ak AccountKeeper, bk authtypes.BankKeeper, fk Feegran
 func checkTxFee(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {
-		return nil, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+		return nil, errorsmod.Wrap(sdkerrors.ErrTxDecode, ErrorTxFeeTx)
 	}
 
 	feeCoins := feeTx.GetFee()
@@ -74,7 +74,7 @@ func checkTxFee(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, error) {
 func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {
-		return ctx, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+		return ctx, errorsmod.Wrap(sdkerrors.ErrTxDecode, ErrorTxFeeTx)
 	}
 
 	if !simulate && ctx.BlockHeight() > 0 && feeTx.GetGas() == 0 {
@@ -102,7 +102,7 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee sdk.Coins) error {
 	feeTx, ok := sdkTx.(sdk.FeeTx)
 	if !ok {
-		return errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+		return errorsmod.Wrap(sdkerrors.ErrTxDecode, ErrorTxFeeTx)
 	}
 
 	if addr := dfd.accountKeeper.GetModuleAddress(authtypes.FeeCollectorName); addr == nil {

--- a/app/ante/error.go
+++ b/app/ante/error.go
@@ -1,0 +1,6 @@
+package ante
+
+var (
+	ErrorAnteContext = "error during CheckTx or ReCheckTx"
+	ErrorTxFeeTx     = "Tx must be a FeeTx"
+)

--- a/app/ante/redeem_claim_decorator.go
+++ b/app/ante/redeem_claim_decorator.go
@@ -52,7 +52,7 @@ func (rcd RedeemClaimDecorator) handleCreateRedeemClaim(ctx sdk.Context, msg sdk
 	balance := rcd.bk.GetBalance(ctx, addr, params.ClaimDenom)
 
 	if !balance.Amount.GTE(sdk.NewIntFromUint64(createRedeemClaimMsg.Amount)) {
-		return ctx, errorsmod.Wrap(sdkerrors.ErrInsufficientFunds, "error during checkTx or reCheckTx")
+		return ctx, errorsmod.Wrap(sdkerrors.ErrInsufficientFunds, ErrorAnteContext)
 	}
 
 	return ctx, nil

--- a/errormsg/error.go
+++ b/errormsg/error.go
@@ -2,4 +2,5 @@ package errormsg
 
 var (
 	ErrorInvalidCreator = "invalid creator address (%s)"
+	InvalidRequest      = "invalid request"
 )

--- a/errormsg/error.go
+++ b/errormsg/error.go
@@ -1,0 +1,5 @@
+package errormsg
+
+var (
+	ErrorInvalidCreator = "invalid creator address (%s)"
+)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,2 @@
 sonar.projectKey=planetmint_planetmint-go_AYjnSLNdwwdSy162QoXI
-sonar.exclusions=docs/static/openapi.yml,x/**/*.pb.go,x/**/*.pb.gw.go,x/**/module.go,x/**/types/genesis_test.go,x/**/types/params.go,x/**/client/cli/query_params.go,tests/e2e/**/suite.go,app/simulation_test.go
+sonar.exclusions=docs/static/openapi.yml,x/**/*.pb.go,x/**/*.pb.gw.go,x/**/module.go,x/**/types/genesis_test.go,x/**/types/params.go,x/**/client/cli/query_params.go,tests/e2e/**/suite.go,app/simulation_test.go,x/**/client/cli/tx_update_params.go,x/**/types/message_update_params_test.go,x/**/keeper/message_server_update_params.go

--- a/tests/e2e/dao/gas_consumption_suite.go
+++ b/tests/e2e/dao/gas_consumption_suite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/planetmint/planetmint-go/lib"
 	clitestutil "github.com/planetmint/planetmint-go/testutil/cli"
 	e2etestutil "github.com/planetmint/planetmint-go/testutil/e2e"
+	"github.com/planetmint/planetmint-go/testutil/moduleobject"
 	"github.com/planetmint/planetmint-go/testutil/network"
 	"github.com/planetmint/planetmint-go/testutil/sample"
 	daotypes "github.com/planetmint/planetmint-go/x/dao/types"
@@ -155,7 +156,7 @@ func (s *GasConsumptionE2ETestSuite) TestNetworkBasedTxGasLimit() {
 	var msgs []sdk.Msg
 
 	for i := 0; i < 1000; i++ {
-		mintRequest := sample.MintRequest(s.minterAddr.String(), 1, "hash"+strconv.Itoa(i))
+		mintRequest := moduleobject.MintRequest(s.minterAddr.String(), 1, "hash"+strconv.Itoa(i))
 		msg := daotypes.NewMsgMintToken(s.minterAddr.String(), &mintRequest)
 		msgs = append(msgs, msg)
 	}

--- a/tests/e2e/dao/pop_participant_selection_suite.go
+++ b/tests/e2e/dao/pop_participant_selection_suite.go
@@ -51,10 +51,13 @@ type PopSelectionE2ETestSuite struct {
 	distributionOffset int64
 	claimDenom         string
 	feeDenom           string
+	errormsg           string
 }
 
 func NewPopSelectionE2ETestSuite(cfg network.Config) *PopSelectionE2ETestSuite {
-	return &PopSelectionE2ETestSuite{cfg: cfg}
+	testsuite := &PopSelectionE2ETestSuite{cfg: cfg}
+	testsuite.errormsg = "--%s=%s"
+	return testsuite
 }
 
 func (s *PopSelectionE2ETestSuite) SetupSuite() {
@@ -183,7 +186,7 @@ func (s *PopSelectionE2ETestSuite) VerifyTokens(token string) {
 	val := s.network.Validators[0]
 	// check balance for crddl
 	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, bank.GetCmdQueryTotalSupply(), []string{
-		fmt.Sprintf("--%s=%s", bank.FlagDenom, token),
+		fmt.Sprintf(s.errormsg, bank.FlagDenom, token),
 	})
 	s.Require().NoError(err)
 	assert.Contains(s.T(), out.String(), token)
@@ -191,7 +194,7 @@ func (s *PopSelectionE2ETestSuite) VerifyTokens(token string) {
 
 	out, err = clitestutil.ExecTestCLICmd(val.ClientCtx, bank.GetBalancesCmd(), []string{
 		machines[0].address,
-		fmt.Sprintf("--%s=%s", bank.FlagDenom, token),
+		fmt.Sprintf(s.errormsg, bank.FlagDenom, token),
 	})
 	s.Require().NoError(err)
 	assert.Contains(s.T(), out.String(), token)
@@ -199,7 +202,7 @@ func (s *PopSelectionE2ETestSuite) VerifyTokens(token string) {
 
 	out, err = clitestutil.ExecTestCLICmd(val.ClientCtx, bank.GetBalancesCmd(), []string{
 		machines[1].address,
-		fmt.Sprintf("--%s=%s", bank.FlagDenom, token),
+		fmt.Sprintf(s.errormsg, bank.FlagDenom, token),
 	})
 	s.Require().NoError(err)
 	assert.Contains(s.T(), out.String(), token)
@@ -267,7 +270,7 @@ func (s *PopSelectionE2ETestSuite) TestTokenRedeemClaim() {
 	// Claim burned on CreateRedeemClaim
 	balanceOut, err := clitestutil.ExecTestCLICmd(val.ClientCtx, bank.GetBalancesCmd(), []string{
 		addr.String(),
-		fmt.Sprintf("--%s=%s", bank.FlagDenom, s.claimDenom),
+		fmt.Sprintf(s.errormsg, bank.FlagDenom, s.claimDenom),
 	})
 	s.Require().NoError(err)
 	assert.Equal(s.T(), "amount: \"5993140682\"\ndenom: crddl\n", balanceOut.String()) // 3 * 1997716894 - 10000 = 5993140682

--- a/tests/e2e/dao/suite.go
+++ b/tests/e2e/dao/suite.go
@@ -21,6 +21,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/planetmint/planetmint-go/testutil/moduleobject"
 	daotypes "github.com/planetmint/planetmint-go/x/dao/types"
 )
 
@@ -114,7 +115,7 @@ func (s *E2ETestSuite) TearDownSuite() {
 func (s *E2ETestSuite) TestMintToken() {
 	val := s.network.Validators[0]
 
-	mintRequest := sample.MintRequest(s.aliceAddr.String(), 1000, "hash")
+	mintRequest := moduleobject.MintRequest(s.aliceAddr.String(), 1000, "hash")
 	msg1 := daotypes.NewMsgMintToken(val.Address.String(), &mintRequest)
 	out, err := e2etestutil.BuildSignBroadcastTx(s.T(), val.Address, msg1)
 	s.Require().NoError(err)

--- a/tests/e2e/machine/suite.go
+++ b/tests/e2e/machine/suite.go
@@ -15,6 +15,8 @@ import (
 	e2etestutil "github.com/planetmint/planetmint-go/testutil/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/planetmint/planetmint-go/testutil/moduleobject"
 )
 
 // E2ETestSuite struct definition of machine suite
@@ -57,7 +59,7 @@ func (s *E2ETestSuite) TestAttestMachine() {
 	// register Ta
 	prvKey, pubKey := sample.KeyPair()
 
-	ta := sample.TrustAnchor(pubKey)
+	ta := moduleobject.TrustAnchor(pubKey)
 	msg1 := machinetypes.NewMsgRegisterTrustAnchor(val.Address.String(), &ta)
 	out, err := e2etestutil.BuildSignBroadcastTx(s.T(), val.Address, msg1)
 	s.Require().NoError(err)
@@ -72,7 +74,7 @@ func (s *E2ETestSuite) TestAttestMachine() {
 	s.Require().NoError(err)
 	addr, _ := k.GetAddress()
 
-	machine := sample.Machine(sample.Name, pubKey, prvKey, addr.String())
+	machine := moduleobject.Machine(sample.Name, pubKey, prvKey, addr.String())
 	msg2 := machinetypes.NewMsgAttestMachine(addr.String(), &machine)
 	out, err = e2etestutil.BuildSignBroadcastTx(s.T(), addr, msg2)
 	s.Require().NoError(err)
@@ -105,7 +107,7 @@ func (s *E2ETestSuite) TestInvalidAttestMachine() {
 	s.Require().NoError(err)
 	addr, _ := k.GetAddress()
 
-	machine := sample.Machine(sample.Name, pubKey, prvKey, addr.String())
+	machine := moduleobject.Machine(sample.Name, pubKey, prvKey, addr.String())
 	s.Require().NoError(err)
 
 	msg := machinetypes.NewMsgAttestMachine(addr.String(), &machine)
@@ -115,7 +117,7 @@ func (s *E2ETestSuite) TestInvalidAttestMachine() {
 	s.Require().Equal(int(txResponse.Code), int(4))
 
 	unregisteredPubKey, unregisteredPrivKey := sample.KeyPair(2)
-	machine = sample.Machine(sample.Name, unregisteredPubKey, unregisteredPrivKey, addr.String())
+	machine = moduleobject.Machine(sample.Name, unregisteredPubKey, unregisteredPrivKey, addr.String())
 	s.Require().NoError(err)
 
 	msg = machinetypes.NewMsgAttestMachine(addr.String(), &machine)
@@ -139,7 +141,7 @@ func (s *E2ETestSuite) TestMachineAllowanceAttestation() {
 	// register TA
 	prvKey, pubKey := sample.KeyPair(3)
 
-	ta := sample.TrustAnchor(pubKey)
+	ta := moduleobject.TrustAnchor(pubKey)
 	msg1 := machinetypes.NewMsgRegisterTrustAnchor(val.Address.String(), &ta)
 	_, err = e2etestutil.BuildSignBroadcastTx(s.T(), val.Address, msg1)
 	s.Require().NoError(err)
@@ -163,7 +165,7 @@ func (s *E2ETestSuite) TestMachineAllowanceAttestation() {
 	s.Require().NoError(s.network.WaitForNextBlock())
 
 	// attest machine with fee granter without funding the machine account first
-	machine := sample.Machine(sample.Name, pubKey, prvKey, addr.String())
+	machine := moduleobject.Machine(sample.Name, pubKey, prvKey, addr.String())
 	s.Require().NoError(err)
 
 	// name and address of private key with which to sign

--- a/testutil/e2e/e2e.go
+++ b/testutil/e2e/e2e.go
@@ -10,6 +10,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/planetmint/planetmint-go/lib"
 	clitestutil "github.com/planetmint/planetmint-go/testutil/cli"
+	moduleobjects "github.com/planetmint/planetmint-go/testutil/moduleobject"
 	"github.com/planetmint/planetmint-go/testutil/network"
 	"github.com/planetmint/planetmint-go/testutil/sample"
 	machinetypes "github.com/planetmint/planetmint-go/x/machine/types"
@@ -75,8 +76,7 @@ func AttestMachine(network *network.Network, name string, mnemonic string, num i
 
 	// register Ta
 	prvKey, pubKey := sample.KeyPair(num)
-
-	ta := sample.TrustAnchor(pubKey)
+	ta := moduleobjects.TrustAnchor(pubKey)
 	registerMsg := machinetypes.NewMsgRegisterTrustAnchor(val.Address.String(), &ta)
 	_, err = lib.BroadcastTxWithFileLock(val.Address, registerMsg)
 	if err != nil {
@@ -92,7 +92,7 @@ func AttestMachine(network *network.Network, name string, mnemonic string, num i
 		return err
 	}
 
-	machine := sample.Machine(name, pubKey, prvKey, addr.String())
+	machine := moduleobjects.Machine(name, pubKey, prvKey, addr.String())
 	attestMsg := machinetypes.NewMsgAttestMachine(addr.String(), &machine)
 	_, err = lib.BroadcastTxWithFileLock(addr, attestMsg)
 	if err != nil {

--- a/testutil/errormsg/error.go
+++ b/testutil/errormsg/error.go
@@ -1,4 +1,4 @@
-package sample
+package errormsg
 
 var (
 	ErrorInvalidAddress = "invalid_address"

--- a/testutil/keeper/asset.go
+++ b/testutil/keeper/asset.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/planetmint/planetmint-go/config"
+	"github.com/planetmint/planetmint-go/testutil/moduleobject"
 	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/planetmint/planetmint-go/x/asset/keeper"
 	"github.com/planetmint/planetmint-go/x/asset/types"
@@ -49,15 +50,15 @@ func AssetKeeper(t testing.TB) (*keeper.Keeper, sdk.Context) {
 	ctrl := gomock.NewController(t)
 	mk := assettestutils.NewMockMachineKeeper(ctrl)
 	sk, pk := sample.KeyPair()
-	_, ppk := sample.ExtendedKeyPair(config.PlmntNetParams)
-	_, lpk := sample.ExtendedKeyPair(config.LiquidNetParams)
+	_, ppk := moduleobject.ExtendedKeyPair(config.PlmntNetParams)
+	_, lpk := moduleobject.ExtendedKeyPair(config.LiquidNetParams)
 
-	id := sample.MachineIndex(pk, ppk, lpk)
+	id := moduleobject.MachineIndex(pk, ppk, lpk)
 	mk.EXPECT().GetMachineIndexByPubKey(ctx, pk).Return(id, true).AnyTimes()
 	mk.EXPECT().GetMachineIndexByPubKey(ctx, ppk).Return(id, true).AnyTimes()
 	mk.EXPECT().GetMachineIndexByPubKey(ctx, sk).Return(id, false).AnyTimes()
-	mk.EXPECT().GetMachine(ctx, id).Return(sample.Machine(pk, pk, sk, ""), true).AnyTimes()
-	mk.EXPECT().GetMachine(ctx, sk).Return(sample.Machine(pk, pk, sk, ""), false).AnyTimes()
+	mk.EXPECT().GetMachine(ctx, id).Return(moduleobject.Machine(pk, pk, sk, ""), true).AnyTimes()
+	mk.EXPECT().GetMachine(ctx, sk).Return(moduleobject.Machine(pk, pk, sk, ""), false).AnyTimes()
 
 	k := keeper.NewKeeper(
 		cdc,

--- a/testutil/moduleobject/sampleobject.go
+++ b/testutil/moduleobject/sampleobject.go
@@ -1,0 +1,98 @@
+package moduleobject
+
+import (
+	"encoding/hex"
+
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/planetmint/planetmint-go/config"
+	"github.com/planetmint/planetmint-go/testutil/sample"
+	daotypes "github.com/planetmint/planetmint-go/x/dao/types"
+	machinetypes "github.com/planetmint/planetmint-go/x/machine/types"
+
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/cosmos/go-bip39"
+)
+
+func ExtendedKeyPair(cfg chaincfg.Params) (string, string) {
+	seed, err := bip39.NewSeedWithErrorChecking(sample.Mnemonic, keyring.DefaultBIP39Passphrase)
+	if err != nil {
+		panic(err)
+	}
+	xprivKey, err := hdkeychain.NewMaster(seed, &cfg)
+	if err != nil {
+		panic(err)
+	}
+	xpubKey, err := xprivKey.Neuter()
+	if err != nil {
+		panic(err)
+	}
+	return xprivKey.String(), xpubKey.String()
+}
+
+// Machine creates a new machine object
+// TODO: make address deterministic for test cases
+func Machine(name, pubKey string, prvKey string, address string) machinetypes.Machine {
+	metadata := Metadata()
+	_, liquidPubKey := ExtendedKeyPair(config.LiquidNetParams)
+	_, planetmintPubKey := ExtendedKeyPair(config.PlmntNetParams)
+
+	prvKeyBytes, _ := hex.DecodeString(prvKey)
+	sk := &secp256k1.PrivKey{Key: prvKeyBytes}
+	pubKeyBytes, _ := hex.DecodeString(pubKey)
+	sign, _ := sk.Sign(pubKeyBytes)
+	signatureHex := hex.EncodeToString(sign)
+
+	if address == "" {
+		address = sample.Secp256k1AccAddress().String()
+	}
+
+	m := machinetypes.Machine{
+		Name:               name,
+		Ticker:             name + "_ticker",
+		Domain:             "lab.r3c.network",
+		Reissue:            true,
+		Amount:             1000,
+		Precision:          8,
+		IssuerPlanetmint:   planetmintPubKey,
+		IssuerLiquid:       liquidPubKey,
+		MachineId:          pubKey,
+		Metadata:           &metadata,
+		Type:               1,
+		MachineIdSignature: signatureHex,
+		Address:            address,
+	}
+	return m
+}
+
+func MachineIndex(pubKey string, planetmintPubKey string, liquidPubKey string) machinetypes.MachineIndex {
+	return machinetypes.MachineIndex{
+		MachineId:        pubKey,
+		IssuerPlanetmint: planetmintPubKey,
+		IssuerLiquid:     liquidPubKey,
+	}
+}
+
+func Metadata() machinetypes.Metadata {
+	return machinetypes.Metadata{
+		Gps:               "{\"Latitude\":\"-48.876667\",\"Longitude\":\"-123.393333\"}",
+		Device:            "{\"Manufacturer\": \"RDDL\",\"Serial\":\"AdnT2uyt\"}",
+		AssetDefinition:   "{\"Version\": \"0.1\"}",
+		AdditionalDataCID: "CID",
+	}
+}
+
+func TrustAnchor(pubkey string) machinetypes.TrustAnchor {
+	return machinetypes.TrustAnchor{
+		Pubkey: pubkey,
+	}
+}
+
+func MintRequest(beneficiaryAddr string, amount uint64, txhash string) daotypes.MintRequest {
+	return daotypes.MintRequest{
+		Beneficiary:  beneficiaryAddr,
+		Amount:       amount,
+		LiquidTxHash: txhash,
+	}
+}

--- a/testutil/sample/error.go
+++ b/testutil/sample/error.go
@@ -1,0 +1,5 @@
+package sample
+
+var (
+	ErrorInvalidAddress = "invalid_address"
+)

--- a/testutil/sample/sample.go
+++ b/testutil/sample/sample.go
@@ -4,10 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/planetmint/planetmint-go/config"
-	daotypes "github.com/planetmint/planetmint-go/x/dao/types"
-	machinetypes "github.com/planetmint/planetmint-go/x/machine/types"
-
 	"github.com/btcsuite/btcd/btcutil/hdkeychain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -60,58 +56,6 @@ func Secp256k1AccAddress() sdk.AccAddress {
 	return sdk.AccAddress(addr)
 }
 
-// Machine creates a new machine object
-// TODO: make address deterministic for test cases
-func Machine(name, pubKey string, prvKey string, address string) machinetypes.Machine {
-	metadata := Metadata()
-	_, liquidPubKey := ExtendedKeyPair(config.LiquidNetParams)
-	_, planetmintPubKey := ExtendedKeyPair(config.PlmntNetParams)
-
-	prvKeyBytes, _ := hex.DecodeString(prvKey)
-	sk := &secp256k1.PrivKey{Key: prvKeyBytes}
-	pubKeyBytes, _ := hex.DecodeString(pubKey)
-	sign, _ := sk.Sign(pubKeyBytes)
-	signatureHex := hex.EncodeToString(sign)
-
-	if address == "" {
-		address = Secp256k1AccAddress().String()
-	}
-
-	m := machinetypes.Machine{
-		Name:               name,
-		Ticker:             name + "_ticker",
-		Domain:             "lab.r3c.network",
-		Reissue:            true,
-		Amount:             1000,
-		Precision:          8,
-		IssuerPlanetmint:   planetmintPubKey,
-		IssuerLiquid:       liquidPubKey,
-		MachineId:          pubKey,
-		Metadata:           &metadata,
-		Type:               1,
-		MachineIdSignature: signatureHex,
-		Address:            address,
-	}
-	return m
-}
-
-func MachineIndex(pubKey string, planetmintPubKey string, liquidPubKey string) machinetypes.MachineIndex {
-	return machinetypes.MachineIndex{
-		MachineId:        pubKey,
-		IssuerPlanetmint: planetmintPubKey,
-		IssuerLiquid:     liquidPubKey,
-	}
-}
-
-func Metadata() machinetypes.Metadata {
-	return machinetypes.Metadata{
-		Gps:               "{\"Latitude\":\"-48.876667\",\"Longitude\":\"-123.393333\"}",
-		Device:            "{\"Manufacturer\": \"RDDL\",\"Serial\":\"AdnT2uyt\"}",
-		AssetDefinition:   "{\"Version\": \"0.1\"}",
-		AdditionalDataCID: "CID",
-	}
-}
-
 func Asset() string {
 	cid := "cid0"
 	return cid
@@ -131,18 +75,4 @@ func ExtendedKeyPair(cfg chaincfg.Params) (string, string) {
 		panic(err)
 	}
 	return xprivKey.String(), xpubKey.String()
-}
-
-func TrustAnchor(pubkey string) machinetypes.TrustAnchor {
-	return machinetypes.TrustAnchor{
-		Pubkey: pubkey,
-	}
-}
-
-func MintRequest(beneficiaryAddr string, amount uint64, txhash string) daotypes.MintRequest {
-	return daotypes.MintRequest{
-		Beneficiary:  beneficiaryAddr,
-		Amount:       amount,
-		LiquidTxHash: txhash,
-	}
 }

--- a/util/rddl_token_test.go
+++ b/util/rddl_token_test.go
@@ -6,7 +6,9 @@ import (
 	"gotest.tools/assert"
 )
 
-var rddlTokenAmount string = "998.85844748"
+const (
+	rddlTokenAmount string = "998.85844748"
+)
 
 func Test2FloatConvertion(t *testing.T) {
 	t.Parallel()

--- a/util/rddl_token_test.go
+++ b/util/rddl_token_test.go
@@ -6,6 +6,8 @@ import (
 	"gotest.tools/assert"
 )
 
+var rddlTokenAmount string = "998.85844748"
+
 func Test2FloatConvertion(t *testing.T) {
 	t.Parallel()
 	var expectedValue uint64 = 99885844748
@@ -23,7 +25,7 @@ func Test2UintConvertion(t *testing.T) {
 func TestStringToFloat(t *testing.T) {
 	t.Parallel()
 	expectedValue := 998.85844748
-	value, err := RDDLTokenStringToFloat("998.85844748")
+	value, err := RDDLTokenStringToFloat(rddlTokenAmount)
 	assert.Equal(t, expectedValue, value)
 	assert.Equal(t, nil, err)
 }
@@ -31,7 +33,7 @@ func TestStringToFloat(t *testing.T) {
 func TestStringToUint(t *testing.T) {
 	t.Parallel()
 	var expectedValue uint64 = 99885844748
-	value, err := RDDLTokenStringToUint("998.85844748")
+	value, err := RDDLTokenStringToUint(rddlTokenAmount)
 	assert.Equal(t, expectedValue, value)
 	assert.Equal(t, nil, err)
 }
@@ -40,7 +42,7 @@ func TestAddPrecisionLongerThan8(t *testing.T) {
 	t.Parallel()
 
 	var input uint64 = 99885844748
-	expectedValue := "998.85844748"
+	expectedValue := rddlTokenAmount
 	rddlTokenString := UintValueToRDDLTokenString(input)
 	assert.Equal(t, expectedValue, rddlTokenString)
 }

--- a/x/asset/keeper/asset_test.go
+++ b/x/asset/keeper/asset_test.go
@@ -28,17 +28,7 @@ func createNAsset(keeper *keeper.Keeper, ctx sdk.Context, n int) []types.MsgNota
 	return items
 }
 
-func TestGetAsset(t *testing.T) {
-	t.Parallel()
-	keeper, ctx := keepertest.AssetKeeper(t)
-	items := createNAsset(keeper, ctx, 10)
-	for _, item := range items {
-		asset, found := keeper.GetAsset(ctx, item.Cid)
-		assert.True(t, found)
-		assert.Equal(t, item, asset)
-	}
-}
-func TestGetCids(t *testing.T) {
+func TestGetAssetbyCid(t *testing.T) {
 	t.Parallel()
 	keeper, ctx := keepertest.AssetKeeper(t)
 	items := createNAsset(keeper, ctx, 10)

--- a/x/asset/keeper/query_address.go
+++ b/x/asset/keeper/query_address.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/asset/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) GetCIDsByAddress(goCtx context.Context, req *types.QueryGetCIDsByAddressRequest) (*types.QueryGetCIDsByAddressResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/asset/keeper/query_cid.go
+++ b/x/asset/keeper/query_cid.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/asset/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) GetNotarizedAsset(goCtx context.Context, req *types.QueryGetNotarizedAssetRequest) (*types.QueryGetNotarizedAssetResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/asset/keeper/query_params.go
+++ b/x/asset/keeper/query_params.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/asset/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 

--- a/x/asset/types/message_notarize_asset.go
+++ b/x/asset/types/message_notarize_asset.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgNotarizeAsset = "notarize_asset"
@@ -41,7 +42,7 @@ func (msg *MsgNotarizeAsset) GetSignBytes() []byte {
 func (msg *MsgNotarizeAsset) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/asset/types/message_notarize_asset_test.go
+++ b/x/asset/types/message_notarize_asset_test.go
@@ -3,7 +3,7 @@ package types
 import (
 	"testing"
 
-	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/testutil/errormsg"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/stretchr/testify/require"
@@ -19,14 +19,9 @@ func TestMsgNotarizeAssetValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgNotarizeAsset{
-				Creator: sample.ErrorInvalidAddress,
+				Creator: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
-		}, {
-			name: "valid address",
-			msg: MsgNotarizeAsset{
-				Creator: sample.AccAddress(),
-			},
 		},
 	}
 	for _, tt := range tests {

--- a/x/asset/types/message_notarize_asset_test.go
+++ b/x/asset/types/message_notarize_asset_test.go
@@ -19,7 +19,7 @@ func TestMsgNotarizeAssetValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgNotarizeAsset{
-				Creator: "invalid_address",
+				Creator: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		}, {

--- a/x/dao/abci.go
+++ b/x/dao/abci.go
@@ -69,4 +69,5 @@ func isDistributionHeight(ctx sdk.Context, k keeper.Keeper, height int64) bool {
 }
 
 func EndBlocker(_ sdk.Context, _ abci.RequestEndBlock, _ keeper.Keeper) {
+	// EndBlocker is currently not implemented and used by planetmint
 }

--- a/x/dao/keeper/msg_server_reissue_rddl_result.go
+++ b/x/dao/keeper/msg_server_reissue_rddl_result.go
@@ -11,19 +11,19 @@ import (
 
 func (k msgServer) ReissueRDDLResult(goCtx context.Context, msg *types.MsgReissueRDDLResult) (*types.MsgReissueRDDLResultResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-
+	errmsg := " for provided block height %s"
 	reissuance, found := k.LookupReissuance(ctx, msg.GetBlockHeight())
 	if !found {
-		return nil, errorsmod.Wrapf(types.ErrReissuanceNotFound, " for provided block height %s", strconv.FormatInt(msg.GetBlockHeight(), 10))
+		return nil, errorsmod.Wrapf(types.ErrReissuanceNotFound, errmsg, strconv.FormatInt(msg.GetBlockHeight(), 10))
 	}
 	if reissuance.GetBlockHeight() != msg.GetBlockHeight() {
-		return nil, errorsmod.Wrapf(types.ErrWrongBlockHeight, " for provided block height %s", strconv.FormatInt(msg.GetBlockHeight(), 10))
+		return nil, errorsmod.Wrapf(types.ErrWrongBlockHeight, errmsg, strconv.FormatInt(msg.GetBlockHeight(), 10))
 	}
 	if reissuance.GetProposer() != msg.GetProposer() {
-		return nil, errorsmod.Wrapf(types.ErrInvalidProposer, " for provided block height %s", strconv.FormatInt(msg.GetBlockHeight(), 10))
+		return nil, errorsmod.Wrapf(types.ErrInvalidProposer, errmsg, strconv.FormatInt(msg.GetBlockHeight(), 10))
 	}
 	if reissuance.GetTxID() != "" {
-		return nil, errorsmod.Wrapf(types.ErrTXAlreadySet, " for provided block height %s", strconv.FormatInt(msg.GetBlockHeight(), 10))
+		return nil, errorsmod.Wrapf(types.ErrTXAlreadySet, errmsg, strconv.FormatInt(msg.GetBlockHeight(), 10))
 	}
 	reissuance.TxID = msg.GetTxID()
 

--- a/x/dao/keeper/msg_server_test.go
+++ b/x/dao/keeper/msg_server_test.go
@@ -7,6 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	keepertest "github.com/planetmint/planetmint-go/testutil/keeper"
+	"github.com/planetmint/planetmint-go/testutil/moduleobject"
 	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/planetmint/planetmint-go/x/dao/keeper"
 	"github.com/planetmint/planetmint-go/x/dao/types"
@@ -170,7 +171,7 @@ func TestMsgServerMintToken(t *testing.T) {
 	t.Parallel()
 	minter := sample.AccAddress()
 	beneficiary := sample.ConstBech32Addr
-	mintRequest := sample.MintRequest(beneficiary, 1000, "hash")
+	mintRequest := moduleobject.MintRequest(beneficiary, 1000, "hash")
 
 	msg := types.NewMsgMintToken(minter, &mintRequest)
 	msgServer, ctx, _ := setupMsgServer(t)
@@ -190,7 +191,7 @@ func TestMsgServerMintTokenInvalidAddress(t *testing.T) {
 	t.Parallel()
 	minter := sample.AccAddress()
 	beneficiary := "invalid address"
-	mintRequest := sample.MintRequest(beneficiary, 1000, "hash")
+	mintRequest := moduleobject.MintRequest(beneficiary, 1000, "hash")
 
 	msg := types.NewMsgMintToken(minter, &mintRequest)
 	msgServer, ctx, _ := setupMsgServer(t)

--- a/x/dao/keeper/msg_server_test.go
+++ b/x/dao/keeper/msg_server_test.go
@@ -31,6 +31,7 @@ func TestMsgServerReportPoPResult(t *testing.T) {
 	initiator := sample.Secp256k1AccAddress()
 	challenger := sample.Secp256k1AccAddress()
 	challengee := sample.Secp256k1AccAddress()
+	errInvalidPopData := "Invalid pop data"
 
 	testCases := []struct {
 		name   string
@@ -81,7 +82,7 @@ func TestMsgServerReportPoPResult(t *testing.T) {
 			"Initiator is not set: invalid challenge",
 		},
 		{
-			"Invalid pop data",
+			errInvalidPopData,
 			types.MsgReportPopResult{
 				Creator: challenger.String(),
 				Challenge: &types.Challenge{
@@ -96,7 +97,7 @@ func TestMsgServerReportPoPResult(t *testing.T) {
 			"PoP report data does not match challenge: invalid challenge",
 		},
 		{
-			"Invalid pop data",
+			errInvalidPopData,
 			types.MsgReportPopResult{
 				Creator: challenger.String(),
 				Challenge: &types.Challenge{
@@ -111,7 +112,7 @@ func TestMsgServerReportPoPResult(t *testing.T) {
 			"PoP reporter is not the challenger: invalid PoP reporter",
 		},
 		{
-			"Invalid pop data",
+			errInvalidPopData,
 			types.MsgReportPopResult{
 				Creator: challenger.String(),
 				Challenge: &types.Challenge{

--- a/x/dao/keeper/query_challenges.go
+++ b/x/dao/keeper/query_challenges.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -13,7 +14,7 @@ import (
 
 func (k Keeper) Challenges(goCtx context.Context, req *types.QueryChallengesRequest) (*types.QueryChallengesResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/dao/keeper/query_get_challenge.go
+++ b/x/dao/keeper/query_get_challenge.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) GetChallenge(goCtx context.Context, req *types.QueryGetChallengeRequest) (*types.QueryGetChallengeResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/dao/keeper/query_get_distribution.go
+++ b/x/dao/keeper/query_get_distribution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) GetDistribution(goCtx context.Context, req *types.QueryGetDistributionRequest) (*types.QueryGetDistributionResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/dao/keeper/query_get_mint_requests_by_hash.go
+++ b/x/dao/keeper/query_get_mint_requests_by_hash.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) GetMintRequestsByHash(goCtx context.Context, req *types.QueryGetMintRequestsByHashRequest) (*types.QueryGetMintRequestsByHashResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/dao/keeper/query_get_reissuance.go
+++ b/x/dao/keeper/query_get_reissuance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) GetReissuance(goCtx context.Context, req *types.QueryGetReissuanceRequest) (*types.QueryGetReissuanceResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/dao/keeper/query_mint_requests_by_address.go
+++ b/x/dao/keeper/query_mint_requests_by_address.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) MintRequestsByAddress(goCtx context.Context, req *types.QueryMintRequestsByAddressRequest) (*types.QueryMintRequestsByAddressResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/dao/keeper/query_params.go
+++ b/x/dao/keeper/query_params.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 

--- a/x/dao/keeper/query_redeem_claim.go
+++ b/x/dao/keeper/query_redeem_claim.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -13,7 +14,7 @@ import (
 
 func (k Keeper) RedeemClaimAll(goCtx context.Context, req *types.QueryAllRedeemClaimRequest) (*types.QueryAllRedeemClaimResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	var redeemClaims []types.RedeemClaim
@@ -42,7 +43,7 @@ func (k Keeper) RedeemClaimAll(goCtx context.Context, req *types.QueryAllRedeemC
 
 func (k Keeper) RedeemClaim(goCtx context.Context, req *types.QueryGetRedeemClaimRequest) (*types.QueryGetRedeemClaimResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -60,7 +61,7 @@ func (k Keeper) RedeemClaim(goCtx context.Context, req *types.QueryGetRedeemClai
 
 func (k Keeper) RedeemClaimByLiquidTxHash(goCtx context.Context, req *types.QueryRedeemClaimByLiquidTxHashRequest) (*types.QueryRedeemClaimByLiquidTxHashResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/dao/keeper/query_redeem_claim_test.go
+++ b/x/dao/keeper/query_redeem_claim_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/planetmint/planetmint-go/errormsg"
 	keepertest "github.com/planetmint/planetmint-go/testutil/keeper"
 	"github.com/planetmint/planetmint-go/testutil/nullify"
 	"github.com/planetmint/planetmint-go/x/dao/types"
@@ -54,7 +55,7 @@ func TestRedeemClaimQuerySingle(t *testing.T) {
 		},
 		{
 			desc: "InvalidRequest",
-			err:  status.Error(codes.InvalidArgument, "invalid request"),
+			err:  status.Error(codes.InvalidArgument, errormsg.InvalidRequest),
 		},
 	}
 	for _, tc := range tests {
@@ -125,6 +126,6 @@ func TestRedeemClaimQueryPaginated(t *testing.T) {
 	})
 	t.Run("InvalidRequest", func(t *testing.T) {
 		_, err := keeper.RedeemClaimAll(wctx, nil)
-		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "invalid request"))
+		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, errormsg.InvalidRequest))
 	})
 }

--- a/x/dao/keeper/query_reissuances.go
+++ b/x/dao/keeper/query_reissuances.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/dao/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -13,7 +14,7 @@ import (
 
 func (k Keeper) Reissuances(goCtx context.Context, req *types.QueryReissuancesRequest) (*types.QueryReissuancesResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/dao/module_simulation.go
+++ b/x/dao/module_simulation.go
@@ -72,7 +72,9 @@ func (AppModule) GenerateGenesisState(simState *module.SimulationState) {
 }
 
 // RegisterStoreDecoder registers a decoder.
-func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {}
+func (am AppModule) RegisterStoreDecoder(_ sdk.StoreDecoderRegistry) {
+	// Implement if needed
+}
 
 // ProposalContents doesn't return any content functions for governance proposals.
 func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalMsg {

--- a/x/dao/types/message_distribution_request.go
+++ b/x/dao/types/message_distribution_request.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgDistributionRequest = "distribution_request"
@@ -41,7 +42,7 @@ func (msg *MsgDistributionRequest) GetSignBytes() []byte {
 func (msg *MsgDistributionRequest) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/message_distribution_result.go
+++ b/x/dao/types/message_distribution_result.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgDistributionResult = "distribution_result"
@@ -47,7 +48,7 @@ func (msg *MsgDistributionResult) GetSignBytes() []byte {
 func (msg *MsgDistributionResult) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/message_init_pop.go
+++ b/x/dao/types/message_init_pop.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgInitPop = "init_pop"
@@ -44,7 +45,7 @@ func (msg *MsgInitPop) GetSignBytes() []byte {
 func (msg *MsgInitPop) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/message_init_pop_test.go
+++ b/x/dao/types/message_init_pop_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +18,7 @@ func TestMsgInitPop_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgInitPop{
-				Creator: "invalid_address",
+				Creator: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/dao/types/message_init_pop_test.go
+++ b/x/dao/types/message_init_pop_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/testutil/errormsg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +18,7 @@ func TestMsgInitPop_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgInitPop{
-				Creator: sample.ErrorInvalidAddress,
+				Creator: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/dao/types/message_mint_token.go
+++ b/x/dao/types/message_mint_token.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgMintToken = "mint_token"
@@ -41,7 +42,7 @@ func (msg *MsgMintToken) GetSignBytes() []byte {
 func (msg *MsgMintToken) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/message_mint_token_test.go
+++ b/x/dao/types/message_mint_token_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/testutil/errormsg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +18,7 @@ func TestMsgMintToken_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgMintToken{
-				Creator: sample.ErrorInvalidAddress,
+				Creator: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/dao/types/message_mint_token_test.go
+++ b/x/dao/types/message_mint_token_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +18,7 @@ func TestMsgMintToken_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgMintToken{
-				Creator: "invalid_address",
+				Creator: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/dao/types/message_reissue_rddl_proposal.go
+++ b/x/dao/types/message_reissue_rddl_proposal.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgReissueRDDLProposal = "reissue_rddl_proposal"
@@ -46,7 +47,7 @@ func (msg *MsgReissueRDDLProposal) GetSignBytes() []byte {
 func (msg *MsgReissueRDDLProposal) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/message_reissue_rddl_result.go
+++ b/x/dao/types/message_reissue_rddl_result.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgReissueRDDLResult = "reissue_rddl_result"
@@ -43,7 +44,7 @@ func (msg *MsgReissueRDDLResult) GetSignBytes() []byte {
 func (msg *MsgReissueRDDLResult) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/message_report_pop_result.go
+++ b/x/dao/types/message_report_pop_result.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgReportPopResult = "report_pop_result"
@@ -41,7 +42,7 @@ func (msg *MsgReportPopResult) GetSignBytes() []byte {
 func (msg *MsgReportPopResult) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/message_update_params.go
+++ b/x/dao/types/message_update_params.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgUpdateParams = "update_params"
@@ -41,7 +42,7 @@ func (msg *MsgUpdateParams) GetSignBytes() []byte {
 func (msg *MsgUpdateParams) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Authority)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/message_update_params_test.go
+++ b/x/dao/types/message_update_params_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/testutil/errormsg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +18,7 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgUpdateParams{
-				Authority: sample.ErrorInvalidAddress,
+				Authority: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/dao/types/message_update_params_test.go
+++ b/x/dao/types/message_update_params_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +18,7 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgUpdateParams{
-				Authority: "invalid_address",
+				Authority: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/dao/types/messages_redeem_claim.go
+++ b/x/dao/types/messages_redeem_claim.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const (
@@ -51,7 +52,7 @@ func (msg *MsgCreateRedeemClaim) GetSignBytes() []byte {
 func (msg *MsgCreateRedeemClaim) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }
@@ -97,7 +98,7 @@ func (msg *MsgUpdateRedeemClaim) GetSignBytes() []byte {
 func (msg *MsgUpdateRedeemClaim) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }
@@ -136,7 +137,7 @@ func (msg *MsgConfirmRedeemClaim) GetSignBytes() []byte {
 func (msg *MsgConfirmRedeemClaim) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/dao/types/messages_redeem_claim_test.go
+++ b/x/dao/types/messages_redeem_claim_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/testutil/errormsg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +18,7 @@ func TestMsgCreateRedeemClaim_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgCreateRedeemClaim{
-				Creator: sample.ErrorInvalidAddress,
+				Creator: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},
@@ -47,7 +47,7 @@ func TestMsgUpdateRedeemClaim_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgUpdateRedeemClaim{
-				Creator: sample.ErrorInvalidAddress,
+				Creator: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},
@@ -76,7 +76,7 @@ func TestMsgConfirmRedeemClaim_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgConfirmRedeemClaim{
-				Creator: sample.ErrorInvalidAddress,
+				Creator: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/dao/types/messages_redeem_claim_test.go
+++ b/x/dao/types/messages_redeem_claim_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +18,7 @@ func TestMsgCreateRedeemClaim_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgCreateRedeemClaim{
-				Creator: "invalid_address",
+				Creator: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},
@@ -46,7 +47,7 @@ func TestMsgUpdateRedeemClaim_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgUpdateRedeemClaim{
-				Creator: "invalid_address",
+				Creator: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},
@@ -75,7 +76,7 @@ func TestMsgConfirmRedeemClaim_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgConfirmRedeemClaim{
-				Creator: "invalid_address",
+				Creator: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/machine/keeper/msg_server_test.go
+++ b/x/machine/keeper/msg_server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	keepertest "github.com/planetmint/planetmint-go/testutil/keeper"
+	"github.com/planetmint/planetmint-go/testutil/moduleobject"
 	"github.com/planetmint/planetmint-go/x/machine/keeper"
 	"github.com/planetmint/planetmint-go/x/machine/types"
 
@@ -30,9 +31,9 @@ func TestMsgServer(t *testing.T) {
 func TestMsgServerAttestMachine(t *testing.T) {
 	t.Parallel()
 	sk, pk := sample.KeyPair()
-	ta := sample.TrustAnchor(pk)
+	ta := moduleobject.TrustAnchor(pk)
 	taMsg := types.NewMsgRegisterTrustAnchor(pk, &ta)
-	machine := sample.Machine(pk, pk, sk, "")
+	machine := moduleobject.Machine(pk, pk, sk, "")
 	msg := types.NewMsgAttestMachine(pk, &machine)
 	msgServer, ctx := setupMsgServer(t)
 	_, err := msgServer.RegisterTrustAnchor(ctx, taMsg)
@@ -46,9 +47,9 @@ func TestMsgServerAttestMachine(t *testing.T) {
 func TestMsgServerAttestMachineInvalidLiquidKey(t *testing.T) {
 	t.Parallel()
 	sk, pk := sample.KeyPair()
-	ta := sample.TrustAnchor(pk)
+	ta := moduleobject.TrustAnchor(pk)
 	taMsg := types.NewMsgRegisterTrustAnchor(pk, &ta)
-	machine := sample.Machine(pk, pk, sk, "")
+	machine := moduleobject.Machine(pk, pk, sk, "")
 	machine.IssuerLiquid = "invalidkey"
 	msg := types.NewMsgAttestMachine(pk, &machine)
 	msgServer, ctx := setupMsgServer(t)
@@ -61,7 +62,7 @@ func TestMsgServerAttestMachineInvalidLiquidKey(t *testing.T) {
 func TestMsgServerRegisterTrustAnchor(t *testing.T) {
 	t.Parallel()
 	_, pk := sample.KeyPair()
-	ta := sample.TrustAnchor(pk)
+	ta := moduleobject.TrustAnchor(pk)
 	msg := types.NewMsgRegisterTrustAnchor(pk, &ta)
 	msgServer, ctx := setupMsgServer(t)
 	res, err := msgServer.RegisterTrustAnchor(ctx, msg)
@@ -73,7 +74,7 @@ func TestMsgServerRegisterTrustAnchor(t *testing.T) {
 func TestMsgServerRegisterTrustAnchorTwice(t *testing.T) {
 	t.Parallel()
 	_, pk := sample.KeyPair()
-	ta := sample.TrustAnchor(pk)
+	ta := moduleobject.TrustAnchor(pk)
 	msg := types.NewMsgRegisterTrustAnchor(pk, &ta)
 	msgServer, ctx := setupMsgServer(t)
 	res, err := msgServer.RegisterTrustAnchor(ctx, msg)

--- a/x/machine/keeper/query_get_liquid_assets_by_machineid.go
+++ b/x/machine/keeper/query_get_liquid_assets_by_machineid.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/machine/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) GetLiquidAssetsByMachineid(goCtx context.Context, req *types.QueryGetLiquidAssetsByMachineidRequest) (*types.QueryGetLiquidAssetsByMachineidResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/machine/keeper/query_get_machine_by_address.go
+++ b/x/machine/keeper/query_get_machine_by_address.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/machine/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +13,7 @@ import (
 
 func (k Keeper) GetMachineByAddress(goCtx context.Context, req *types.QueryGetMachineByAddressRequest) (*types.QueryGetMachineByAddressResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/machine/keeper/query_get_machine_by_public_key.go
+++ b/x/machine/keeper/query_get_machine_by_public_key.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/machine/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +13,7 @@ import (
 
 func (k Keeper) GetMachineByPublicKey(goCtx context.Context, req *types.QueryGetMachineByPublicKeyRequest) (*types.QueryGetMachineByPublicKeyResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/machine/keeper/query_get_trust_anchor_status.go
+++ b/x/machine/keeper/query_get_trust_anchor_status.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/machine/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -12,7 +13,7 @@ import (
 
 func (k Keeper) GetTrustAnchorStatus(goCtx context.Context, req *types.QueryGetTrustAnchorStatusRequest) (*types.QueryGetTrustAnchorStatusResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/machine/keeper/query_params.go
+++ b/x/machine/keeper/query_params.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/planetmint/planetmint-go/errormsg"
 	"github.com/planetmint/planetmint-go/x/machine/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -11,7 +12,7 @@ import (
 
 func (k Keeper) Params(goCtx context.Context, req *types.QueryParamsRequest) (*types.QueryParamsResponse, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "invalid request")
+		return nil, status.Error(codes.InvalidArgument, errormsg.InvalidRequest)
 	}
 	ctx := sdk.UnwrapSDKContext(goCtx)
 

--- a/x/machine/types/message_attest_machine.go
+++ b/x/machine/types/message_attest_machine.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgAttestMachine = "attest_machine"
@@ -41,7 +42,7 @@ func (msg *MsgAttestMachine) GetSignBytes() []byte {
 func (msg *MsgAttestMachine) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/machine/types/message_attest_machine_test.go
+++ b/x/machine/types/message_attest_machine_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/testutil/errormsg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +18,7 @@ func TestMsgAttestMachineValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgAttestMachine{
-				Creator: sample.ErrorInvalidAddress,
+				Creator: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/machine/types/message_attest_machine_test.go
+++ b/x/machine/types/message_attest_machine_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +18,7 @@ func TestMsgAttestMachineValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgAttestMachine{
-				Creator: "invalid_address",
+				Creator: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/machine/types/message_notarize_liquid_asset.go
+++ b/x/machine/types/message_notarize_liquid_asset.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgNotarizeLiquidAsset = "notarize_liquid_asset"
@@ -41,7 +42,7 @@ func (msg *MsgNotarizeLiquidAsset) GetSignBytes() []byte {
 func (msg *MsgNotarizeLiquidAsset) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/machine/types/message_register_trust_anchor.go
+++ b/x/machine/types/message_register_trust_anchor.go
@@ -4,6 +4,7 @@ import (
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/errormsg"
 )
 
 const TypeMsgRegisterTrustAnchor = "register_trust_anchor"
@@ -41,7 +42,7 @@ func (msg *MsgRegisterTrustAnchor) GetSignBytes() []byte {
 func (msg *MsgRegisterTrustAnchor) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Creator)
 	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, errormsg.ErrorInvalidCreator, err)
 	}
 	return nil
 }

--- a/x/machine/types/message_register_trust_anchor_test.go
+++ b/x/machine/types/message_register_trust_anchor_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +18,7 @@ func TestMsgRegisterTrustAnchor_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgRegisterTrustAnchor{
-				Creator: "invalid_address",
+				Creator: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/machine/types/message_register_trust_anchor_test.go
+++ b/x/machine/types/message_register_trust_anchor_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/testutil/errormsg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +18,7 @@ func TestMsgRegisterTrustAnchor_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgRegisterTrustAnchor{
-				Creator: sample.ErrorInvalidAddress,
+				Creator: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/machine/types/message_update_params_test.go
+++ b/x/machine/types/message_update_params_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/testutil/errormsg"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +18,7 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgUpdateParams{
-				Authority: sample.ErrorInvalidAddress,
+				Authority: errormsg.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},

--- a/x/machine/types/message_update_params_test.go
+++ b/x/machine/types/message_update_params_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/planetmint/planetmint-go/testutil/sample"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,7 +18,7 @@ func TestMsgUpdateParams_ValidateBasic(t *testing.T) {
 		{
 			name: "invalid address",
 			msg: MsgUpdateParams{
-				Authority: "invalid_address",
+				Authority: sample.ErrorInvalidAddress,
 			},
 			err: sdkerrors.ErrInvalidAddress,
 		},


### PR DESCRIPTION
Refactoring/moving of objects to different packages.
Splitting up the testutil/sample package to contain only x/*/types definitions and no other keeper or module aspects that already contain and come with x/*/types. <- thus resulting in circular imports within the tests.