### PR TITLE
added more sync objects to avoid accidential data races

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -43,8 +43,6 @@ func DefaultConfig() *Config {
 // GetConfig returns the config instance for the SDK.
 func GetConfig() *Config {
 	initConfig.Do(func() {
-		changeLock.Lock()
-		defer changeLock.Unlock()
 		libConfig = DefaultConfig()
 		sdkConfig = sdk.GetConfig()
 		libConfig.SetBech32PrefixForAccount("plmnt")

--- a/lib/config.go
+++ b/lib/config.go
@@ -24,6 +24,7 @@ var (
 	libConfig  *Config
 	sdkConfig  *sdk.Config
 	initConfig sync.Once
+	changeLock sync.Mutex
 )
 
 // DefaultConfig returns library default configuration.
@@ -42,6 +43,8 @@ func DefaultConfig() *Config {
 // GetConfig returns the config instance for the SDK.
 func GetConfig() *Config {
 	initConfig.Do(func() {
+		changeLock.Lock()
+		defer changeLock.Unlock()
 		libConfig = DefaultConfig()
 		sdkConfig = sdk.GetConfig()
 		libConfig.SetBech32PrefixForAccount("plmnt")
@@ -54,48 +57,64 @@ func GetConfig() *Config {
 
 // SetBech32PrefixForAccount sets the bech32 account prefix.
 func (config *Config) SetBech32PrefixForAccount(bech32Prefix string) *Config {
+	changeLock.Lock()
+	defer changeLock.Unlock()
 	sdkConfig.SetBech32PrefixForAccount(bech32Prefix, "pub")
 	return config
 }
 
 // SetEncodingConfig sets the encoding config and must not be nil.
 func (config *Config) SetEncodingConfig(encodingConfig params.EncodingConfig) *Config {
+	changeLock.Lock()
+	defer changeLock.Unlock()
 	config.EncodingConfig = encodingConfig
 	return config
 }
 
 // SetChainID sets the chain ID parameter.
 func (config *Config) SetChainID(chainID string) *Config {
+	changeLock.Lock()
+	defer changeLock.Unlock()
 	config.ChainID = chainID
 	return config
 }
 
 // SetClientCtx sets the client context parameter.
 func (config *Config) SetClientCtx(clientCtx client.Context) *Config {
+	changeLock.Lock()
+	defer changeLock.Unlock()
 	config.ClientCtx = clientCtx
 	return config
 }
 
 // SetFeeDenom sets the fee denominator parameter.
 func (config *Config) SetFeeDenom(feeDenom string) *Config {
+	changeLock.Lock()
+	defer changeLock.Unlock()
 	config.FeeDenom = feeDenom
 	return config
 }
 
 // SetRoot sets the root directory where to find the keyring.
 func (config *Config) SetRoot(root string) *Config {
+	changeLock.Lock()
+	defer changeLock.Unlock()
 	config.RootDir = root
 	return config
 }
 
 // SetRPCEndpoint sets the RPC endpoint to send requests to.
 func (config *Config) SetRPCEndpoint(rpcEndpoint string) *Config {
+	changeLock.Lock()
+	defer changeLock.Unlock()
 	config.RPCEndpoint = rpcEndpoint
 	return config
 }
 
 // SetTxGas sets the amount of Gas for the TX that is send to the network
 func (config *Config) SetTxGas(txGas uint64) *Config {
+	changeLock.Lock()
+	defer changeLock.Unlock()
 	config.TxGas = txGas
 	return config
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -10,13 +10,13 @@ import (
 
 // Config defines library top level configuration.
 type Config struct {
-	ChainID        string                `json:"chain-id"        mapstructure:"chain-id"`
-	ClientCtx      client.Context        `json:"client-ctx"      mapstructure:"client-ctx"`
-	EncodingConfig params.EncodingConfig `json:"encoding-config" mapstructure:"encoding-config"`
-	FeeDenom       string                `json:"fee-denom"       mapstructure:"fee-denom"`
-	RootDir        string                `json:"root-dir"        mapstructure:"root-dir"`
-	RPCEndpoint    string                `json:"rpc-endpoint"    mapstructure:"rpc-endpoint"`
-	TxGas          uint64                `json:"tx-gas"          mapstructure:"tx-gas"`
+	chainID        string                `json:"chain-id"        mapstructure:"chain-id"`
+	clientCtx      client.Context        `json:"client-ctx"      mapstructure:"client-ctx"`
+	encodingConfig params.EncodingConfig `json:"encoding-config" mapstructure:"encoding-config"`
+	feeDenom       string                `json:"fee-denom"       mapstructure:"fee-denom"`
+	rootDir        string                `json:"root-dir"        mapstructure:"root-dir"`
+	rpcEndpoint    string                `json:"rpc-endpoint"    mapstructure:"rpc-endpoint"`
+	txGas          uint64                `json:"tx-gas"          mapstructure:"tx-gas"`
 }
 
 // lib wide global singleton
@@ -30,13 +30,13 @@ var (
 // DefaultConfig returns library default configuration.
 func DefaultConfig() *Config {
 	return &Config{
-		ChainID:        "planetmint-testnet-1",
-		ClientCtx:      client.Context{},
-		EncodingConfig: params.EncodingConfig{},
-		FeeDenom:       "plmnt",
-		RootDir:        "~/.planetmint-go/",
-		RPCEndpoint:    "http://127.0.0.1:26657",
-		TxGas:          200000,
+		chainID:        "planetmint-testnet-1",
+		clientCtx:      client.Context{},
+		encodingConfig: params.EncodingConfig{},
+		feeDenom:       "plmnt",
+		rootDir:        "~/.planetmint-go/",
+		rpcEndpoint:    "http://127.0.0.1:26657",
+		txGas:          200000,
 	}
 }
 
@@ -65,7 +65,7 @@ func (config *Config) SetBech32PrefixForAccount(bech32Prefix string) *Config {
 func (config *Config) SetEncodingConfig(encodingConfig params.EncodingConfig) *Config {
 	changeLock.Lock()
 	defer changeLock.Unlock()
-	config.EncodingConfig = encodingConfig
+	config.encodingConfig = encodingConfig
 	return config
 }
 
@@ -73,7 +73,7 @@ func (config *Config) SetEncodingConfig(encodingConfig params.EncodingConfig) *C
 func (config *Config) SetChainID(chainID string) *Config {
 	changeLock.Lock()
 	defer changeLock.Unlock()
-	config.ChainID = chainID
+	config.chainID = chainID
 	return config
 }
 
@@ -81,7 +81,7 @@ func (config *Config) SetChainID(chainID string) *Config {
 func (config *Config) SetClientCtx(clientCtx client.Context) *Config {
 	changeLock.Lock()
 	defer changeLock.Unlock()
-	config.ClientCtx = clientCtx
+	config.clientCtx = clientCtx
 	return config
 }
 
@@ -89,7 +89,7 @@ func (config *Config) SetClientCtx(clientCtx client.Context) *Config {
 func (config *Config) SetFeeDenom(feeDenom string) *Config {
 	changeLock.Lock()
 	defer changeLock.Unlock()
-	config.FeeDenom = feeDenom
+	config.feeDenom = feeDenom
 	return config
 }
 
@@ -97,7 +97,7 @@ func (config *Config) SetFeeDenom(feeDenom string) *Config {
 func (config *Config) SetRoot(root string) *Config {
 	changeLock.Lock()
 	defer changeLock.Unlock()
-	config.RootDir = root
+	config.rootDir = root
 	return config
 }
 
@@ -105,7 +105,7 @@ func (config *Config) SetRoot(root string) *Config {
 func (config *Config) SetRPCEndpoint(rpcEndpoint string) *Config {
 	changeLock.Lock()
 	defer changeLock.Unlock()
-	config.RPCEndpoint = rpcEndpoint
+	config.rpcEndpoint = rpcEndpoint
 	return config
 }
 
@@ -113,6 +113,6 @@ func (config *Config) SetRPCEndpoint(rpcEndpoint string) *Config {
 func (config *Config) SetTxGas(txGas uint64) *Config {
 	changeLock.Lock()
 	defer changeLock.Unlock()
-	config.TxGas = txGas
+	config.txGas = txGas
 	return config
 }

--- a/lib/config.go
+++ b/lib/config.go
@@ -10,13 +10,13 @@ import (
 
 // Config defines library top level configuration.
 type Config struct {
-	chainID        string                `json:"chain-id"        mapstructure:"chain-id"`
-	clientCtx      client.Context        `json:"client-ctx"      mapstructure:"client-ctx"`
-	encodingConfig params.EncodingConfig `json:"encoding-config" mapstructure:"encoding-config"`
-	feeDenom       string                `json:"fee-denom"       mapstructure:"fee-denom"`
-	rootDir        string                `json:"root-dir"        mapstructure:"root-dir"`
-	rpcEndpoint    string                `json:"rpc-endpoint"    mapstructure:"rpc-endpoint"`
-	txGas          uint64                `json:"tx-gas"          mapstructure:"tx-gas"`
+	chainID        string
+	clientCtx      client.Context
+	encodingConfig params.EncodingConfig
+	feeDenom       string
+	rootDir        string
+	rpcEndpoint    string
+	txGas          uint64
 }
 
 // lib wide global singleton

--- a/lib/tests/e2e/suite.go
+++ b/lib/tests/e2e/suite.go
@@ -61,7 +61,7 @@ func (s *E2ETestSuite) TestBankSendBroadcastTxWithFileLock() {
 	assert.Equal(s.T(), "received wrong fee denom; got: plmnt required: stake: invalid coins", txResponse.RawLog)
 
 	libConfig := lib.GetConfig()
-	libConfig.FeeDenom = "stake"
+	libConfig.SetFeeDenom("stake")
 
 	// incorrect coin
 	out, err = lib.BroadcastTxWithFileLock(val.Address, msg)

--- a/lib/tx.go
+++ b/lib/tx.go
@@ -38,7 +38,7 @@ func getAccountNumberAndSequence(clientCtx client.Context) (accountNumber, seque
 }
 
 func getClientContextAndTxFactory(fromAddress sdk.AccAddress) (clientCtx client.Context, txf tx.Factory, err error) {
-	clientCtx = GetConfig().ClientCtx
+	clientCtx = GetConfig().clientCtx
 	// at least we need an account retriever
 	// it would be better to check for an empty client context, but that does not work at the moment
 	if clientCtx.AccountRetriever == nil {
@@ -70,17 +70,17 @@ func getTxFactoryWithAccountNumberAndSequence(clientCtx client.Context, accountN
 		WithAccountRetriever(clientCtx.AccountRetriever).
 		WithChainID(clientCtx.ChainID).
 		WithFeeGranter(clientCtx.FeeGranter).
-		WithGas(GetConfig().TxGas).
-		WithGasPrices("0.000005" + GetConfig().FeeDenom).
+		WithGas(GetConfig().txGas).
+		WithGasPrices("0.000005" + GetConfig().feeDenom).
 		WithKeybase(clientCtx.Keyring).
 		WithSequence(sequence).
 		WithTxConfig(clientCtx.TxConfig)
 }
 
 func getClientContext(fromAddress sdk.AccAddress) (clientCtx client.Context, err error) {
-	encodingConfig := GetConfig().EncodingConfig
+	encodingConfig := GetConfig().encodingConfig
 
-	rootDir := GetConfig().RootDir
+	rootDir := GetConfig().rootDir
 	input := os.Stdin
 	codec := encodingConfig.Marshaler
 	keyringOptions := []keyring.Option{}
@@ -95,7 +95,7 @@ func getClientContext(fromAddress sdk.AccAddress) (clientCtx client.Context, err
 		return
 	}
 
-	remote := GetConfig().RPCEndpoint
+	remote := GetConfig().rpcEndpoint
 	wsClient, err := comethttp.New(remote, "/websocket")
 	if err != nil {
 		return
@@ -106,7 +106,7 @@ func getClientContext(fromAddress sdk.AccAddress) (clientCtx client.Context, err
 	clientCtx = client.Context{
 		AccountRetriever:  authtypes.AccountRetriever{},
 		BroadcastMode:     "sync",
-		ChainID:           GetConfig().ChainID,
+		ChainID:           GetConfig().chainID,
 		Client:            wsClient,
 		Codec:             codec,
 		From:              fromAddress.String(),

--- a/lib/utils.go
+++ b/lib/utils.go
@@ -60,7 +60,7 @@ func createSequenceDirectory() (path string, err error) {
 		return
 	}
 	homeDir := usr.HomeDir
-	path = filepath.Join(GetConfig().RootDir, "sequence")
+	path = filepath.Join(GetConfig().rootDir, "sequence")
 	// expand tilde to user's home directory
 	if strings.HasPrefix(path, "~/") {
 		path = filepath.Join(homeDir, path[2:])

--- a/tests/e2e/asset/suite.go
+++ b/tests/e2e/asset/suite.go
@@ -4,7 +4,6 @@ import (
 	"github.com/planetmint/planetmint-go/lib"
 	"github.com/planetmint/planetmint-go/testutil/network"
 	"github.com/planetmint/planetmint-go/testutil/sample"
-	"github.com/planetmint/planetmint-go/util"
 
 	clitestutil "github.com/planetmint/planetmint-go/testutil/cli"
 	e2etestutil "github.com/planetmint/planetmint-go/testutil/e2e"
@@ -39,7 +38,6 @@ func (s *E2ETestSuite) SetupSuite() {
 
 // TearDownSuite clean up after testing
 func (s *E2ETestSuite) TearDownSuite() {
-	util.TerminationWaitGroup.Wait()
 	s.T().Log("tearing down e2e asset test suite")
 }
 

--- a/tests/e2e/dao/basic/suite.go
+++ b/tests/e2e/dao/basic/suite.go
@@ -14,7 +14,6 @@ import (
 	e2etestutil "github.com/planetmint/planetmint-go/testutil/e2e"
 	"github.com/planetmint/planetmint-go/testutil/network"
 	"github.com/planetmint/planetmint-go/testutil/sample"
-	"github.com/planetmint/planetmint-go/util"
 	daocli "github.com/planetmint/planetmint-go/x/dao/client/cli"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -110,7 +109,6 @@ func (s *E2ETestSuite) SetupSuite() {
 
 // TearDownSuite clean up after testing
 func (s *E2ETestSuite) TearDownSuite() {
-	util.TerminationWaitGroup.Wait()
 	s.T().Log("tearing down e2e dao test suite")
 }
 

--- a/tests/e2e/dao/distribution/asset_distribution_suite.go
+++ b/tests/e2e/dao/distribution/asset_distribution_suite.go
@@ -6,7 +6,6 @@ import (
 
 	clitestutil "github.com/planetmint/planetmint-go/testutil/cli"
 	"github.com/planetmint/planetmint-go/testutil/network"
-	"github.com/planetmint/planetmint-go/util"
 	daocli "github.com/planetmint/planetmint-go/x/dao/client/cli"
 	daotypes "github.com/planetmint/planetmint-go/x/dao/types"
 	"github.com/stretchr/testify/suite"
@@ -42,7 +41,6 @@ func (s *AssetDistributionE2ETestSuite) SetupSuite() {
 }
 
 func (s *AssetDistributionE2ETestSuite) TearDownSuite() {
-	util.TerminationWaitGroup.Wait()
 	s.T().Log("tearing down e2e dao distribution test suites")
 }
 

--- a/tests/e2e/dao/gas/gas_consumption_suite.go
+++ b/tests/e2e/dao/gas/gas_consumption_suite.go
@@ -15,7 +15,6 @@ import (
 	"github.com/planetmint/planetmint-go/testutil/moduleobject"
 	"github.com/planetmint/planetmint-go/testutil/network"
 	"github.com/planetmint/planetmint-go/testutil/sample"
-	"github.com/planetmint/planetmint-go/util"
 	daotypes "github.com/planetmint/planetmint-go/x/dao/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -94,7 +93,6 @@ func (s *ConsumptionE2ETestSuite) SetupSuite() {
 }
 
 func (s *ConsumptionE2ETestSuite) TearDownSuite() {
-	util.TerminationWaitGroup.Wait()
 	s.T().Log("tearing down e2e dao gas consumption test suites")
 }
 

--- a/tests/e2e/dao/msgs/restricted_msgs_suite.go
+++ b/tests/e2e/dao/msgs/restricted_msgs_suite.go
@@ -6,7 +6,6 @@ import (
 	e2etestutil "github.com/planetmint/planetmint-go/testutil/e2e"
 	"github.com/planetmint/planetmint-go/testutil/network"
 	"github.com/planetmint/planetmint-go/testutil/sample"
-	"github.com/planetmint/planetmint-go/util"
 	daotypes "github.com/planetmint/planetmint-go/x/dao/types"
 	machinetypes "github.com/planetmint/planetmint-go/x/machine/types"
 	"github.com/stretchr/testify/suite"
@@ -45,7 +44,6 @@ func (s *RestrictedMsgsE2ESuite) SetupSuite() {
 }
 
 func (s *RestrictedMsgsE2ESuite) TearDownSuite() {
-	util.TerminationWaitGroup.Wait()
 	s.T().Log("tearing down e2e dao restricted msg test suite")
 }
 

--- a/tests/e2e/dao/pop/selection_suite.go
+++ b/tests/e2e/dao/pop/selection_suite.go
@@ -17,7 +17,6 @@ import (
 	e2etestutil "github.com/planetmint/planetmint-go/testutil/e2e"
 	"github.com/planetmint/planetmint-go/testutil/network"
 	"github.com/planetmint/planetmint-go/testutil/sample"
-	"github.com/planetmint/planetmint-go/util"
 	daocli "github.com/planetmint/planetmint-go/x/dao/client/cli"
 	daotypes "github.com/planetmint/planetmint-go/x/dao/types"
 	"github.com/stretchr/testify/assert"
@@ -87,7 +86,6 @@ func (s *SelectionE2ETestSuite) SetupSuite() {
 
 // TearDownSuite clean up after testing
 func (s *SelectionE2ETestSuite) TearDownSuite() {
-	util.TerminationWaitGroup.Wait()
 	s.T().Log("tearing down e2e dao pop selection test suite")
 }
 

--- a/tests/e2e/machine/suite.go
+++ b/tests/e2e/machine/suite.go
@@ -5,7 +5,6 @@ import (
 	clitestutil "github.com/planetmint/planetmint-go/testutil/cli"
 	"github.com/planetmint/planetmint-go/testutil/network"
 	"github.com/planetmint/planetmint-go/testutil/sample"
-	"github.com/planetmint/planetmint-go/util"
 	machinecli "github.com/planetmint/planetmint-go/x/machine/client/cli"
 	machinetypes "github.com/planetmint/planetmint-go/x/machine/types"
 
@@ -50,7 +49,6 @@ func (s *E2ETestSuite) SetupSuite() {
 
 // TearDownSuite clean up after testing
 func (s *E2ETestSuite) TearDownSuite() {
-	util.TerminationWaitGroup.Wait()
 	s.T().Log("tearing down e2e machine test suite")
 }
 

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -749,7 +749,8 @@ func (n *Network) Cleanup() {
 
 	n.Logger.Log("cleaning up test network...")
 
-	for _, v := range n.Validators {
+	for i := len(n.Validators) - 1; i >= 0; i-- {
+		v := n.Validators[i]
 		if v.tmNode != nil && v.tmNode.IsRunning() {
 			_ = v.tmNode.Stop()
 		}

--- a/testutil/network/network.go
+++ b/testutil/network/network.go
@@ -24,6 +24,7 @@ import (
 	"github.com/planetmint/planetmint-go/config"
 	"github.com/planetmint/planetmint-go/lib"
 	"github.com/planetmint/planetmint-go/testutil/sample"
+	"github.com/planetmint/planetmint-go/util"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 
@@ -766,6 +767,8 @@ func (n *Network) Cleanup() {
 			}
 		}
 	}
+	// waiting for all threads to be terminated
+	util.TerminationWaitGroup.Wait()
 
 	// Give a brief pause for things to finish closing in other processes. Hopefully this helps with the address-in-use errors.
 	// 100ms chosen randomly.

--- a/util/logger.go
+++ b/util/logger.go
@@ -16,6 +16,7 @@ var (
 	globalApplicationLoggerTag string
 	appLogger                  *AppLogger
 	initAppLogger              sync.Once
+	syncTestingLog             sync.Mutex
 )
 
 func init() {
@@ -33,7 +34,9 @@ func GetAppLogger() *AppLogger {
 }
 
 func (logger *AppLogger) SetTestingLogger(testingLogger *testing.T) *AppLogger {
+	syncTestingLog.Lock()
 	logger.testingLogger = testingLogger
+	syncTestingLog.Unlock()
 	return logger
 }
 
@@ -49,7 +52,9 @@ func (logger *AppLogger) testingLog(msg string, keyvals ...interface{}) {
 		return
 	}
 	msg = format(msg, keyvals...)
+	syncTestingLog.Lock()
 	logger.testingLogger.Logf(msg)
+	syncTestingLog.Unlock()
 }
 
 func (logger *AppLogger) Info(ctx sdk.Context, msg string, keyvals ...interface{}) {


### PR DESCRIPTION
* made lib.config.Config attributed private and protected write operations via Mutex
* network.network.cleanup takes down the nodes in reverse order now
* moved the TerminationWaitGroup.Wait call to the cleanup method after validator termination and before the file removal is executed
* added TestingLogger mutex to avoid accidental data races