### PR TITLE
refactor(query): align with cosmos-sdk style

### DIFF
--- a/tests/e2e/asset/suite.go
+++ b/tests/e2e/asset/suite.go
@@ -85,7 +85,7 @@ func (s *E2ETestSuite) TestNotarizeAsset() {
 		if !tc.expectCheckTxErr {
 			assert.Equal(s.T(), int(0), int(txResponse.Code))
 			args := []string{sample.Asset()}
-			asset, err := clitestutil.ExecTestCLICmd(val.ClientCtx, assetcli.CmdGetByCID(), args)
+			asset, err := clitestutil.ExecTestCLICmd(val.ClientCtx, assetcli.GetCmdByCID(), args)
 			s.Require().NoError(err)
 			assert.Contains(s.T(), asset.String(), sample.Asset())
 		} else {

--- a/tests/e2e/dao/basic/suite.go
+++ b/tests/e2e/dao/basic/suite.go
@@ -207,6 +207,6 @@ func (s *E2ETestSuite) TestReissuance() {
 
 	// - because we waited on the reissuance result, see above
 	intValue := strconv.FormatInt(latestHeight-wait, 10)
-	_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.CmdGetReissuance(), []string{intValue})
+	_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.GetCmdReissuance(), []string{intValue})
 	s.Require().NoError(err)
 }

--- a/tests/e2e/dao/distribution/asset_distribution_suite.go
+++ b/tests/e2e/dao/distribution/asset_distribution_suite.go
@@ -91,7 +91,7 @@ func (s *AssetDistributionE2ETestSuite) TestAssetDistribution() {
 	}
 
 	for _, tc := range testCases {
-		_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.CmdGetDistribution(), []string{
+		_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.GetCmdDistribution(), []string{
 			strconv.FormatInt(tc.requestHeight, 10),
 		})
 		if tc.expectedErr == "" {

--- a/tests/e2e/dao/pop/selection_suite.go
+++ b/tests/e2e/dao/pop/selection_suite.go
@@ -122,7 +122,7 @@ func (s *SelectionE2ETestSuite) perpareLocalTest() testutil.BufferWriter {
 		}
 	}
 
-	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.CmdGetChallenge(), []string{
+	out, err := clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.GetCmdChallenge(), []string{
 		strconv.FormatInt(latestHeight-wait, 10),
 	})
 	s.Require().NoError(err)
@@ -331,11 +331,11 @@ func (s *SelectionE2ETestSuite) TestTokenRedeemClaim() {
 	s.Require().NoError(s.network.WaitForNextBlock())
 
 	// QueryRedeemClaim
-	qOut, err := clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.CmdShowRedeemClaim(), []string{"liquidAddress", "0"})
+	qOut, err := clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.GetCmdShowRedeemClaim(), []string{"liquidAddress", "0"})
 	s.Require().NoError(err)
 	assert.Equal(s.T(), "redeemClaim:\n  amount: \"5993160682\"\n  beneficiary: liquidAddress\n  confirmed: true\n  creator: plmnt1kp93kns6hs2066d8qw0uz84fw3vlthewt2ck6p\n  id: \"0\"\n  liquidTxHash: \"0000000000000000000000000000000000000000000000000000000000000000\"\n", qOut.String())
 
-	qOut, err = clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.CmdRedeemClaimByLiquidTxHash(), []string{"0000000000000000000000000000000000000000000000000000000000000000"})
+	qOut, err = clitestutil.ExecTestCLICmd(val.ClientCtx, daocli.GetCmdRedeemClaimByLiquidTxHash(), []string{"0000000000000000000000000000000000000000000000000000000000000000"})
 	s.Require().NoError(err)
 	assert.Equal(s.T(), "redeemClaim:\n  amount: \"5993160682\"\n  beneficiary: liquidAddress\n  confirmed: true\n  creator: plmnt1kp93kns6hs2066d8qw0uz84fw3vlthewt2ck6p\n  id: \"0\"\n  liquidTxHash: \"0000000000000000000000000000000000000000000000000000000000000000\"\n", qOut.String())
 

--- a/tests/e2e/machine/suite.go
+++ b/tests/e2e/machine/suite.go
@@ -111,7 +111,7 @@ func (s *E2ETestSuite) TestAttestMachine() {
 		pubKey,
 	}
 
-	_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdGetMachineByPublicKey(), args)
+	_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.GetCmdMachineByPublicKey(), args)
 	s.Require().NoError(err)
 	txResponse, err := lib.GetTxResponseFromOut(out)
 	s.Require().NoError(err)
@@ -230,6 +230,6 @@ func (s *E2ETestSuite) TestMachineAllowanceAttestation() {
 		pubKey,
 	}
 
-	_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.CmdGetMachineByPublicKey(), args)
+	_, err = clitestutil.ExecTestCLICmd(val.ClientCtx, machinecli.GetCmdMachineByPublicKey(), args)
 	s.Require().NoError(err)
 }

--- a/x/asset/client/cli/query.go
+++ b/x/asset/client/cli/query.go
@@ -24,9 +24,11 @@ func GetQueryCmd(_ string) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	cmd.AddCommand(CmdGetByAddress())
-	cmd.AddCommand(CmdGetByCID())
-	cmd.AddCommand(CmdQueryParams())
+	cmd.AddCommand(
+		GetCmdByAddress(),
+		GetCmdByCID(),
+		GetCmdQueryParams(),
+	)
 
 	// this line is used by starport scaffolding # 1
 

--- a/x/asset/client/cli/query_address.go
+++ b/x/asset/client/cli/query_address.go
@@ -12,7 +12,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetByAddress() *cobra.Command {
+func GetCmdByAddress() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "address [address] [num-elements]",
 		Short: "Query for assets by address",

--- a/x/asset/client/cli/query_cid.go
+++ b/x/asset/client/cli/query_cid.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetByCID() *cobra.Command {
+func GetCmdByCID() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cid [cid]",
 		Short: "Query for assets by CID",

--- a/x/asset/client/cli/query_params.go
+++ b/x/asset/client/cli/query_params.go
@@ -8,7 +8,7 @@ import (
 	"github.com/planetmint/planetmint-go/x/asset/types"
 )
 
-func CmdQueryParams() *cobra.Command {
+func GetCmdQueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Short: "Query the current asset parameters information",

--- a/x/dao/client/cli/query.go
+++ b/x/dao/client/cli/query.go
@@ -21,23 +21,18 @@ func GetQueryCmd(_ string) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	cmd.AddCommand(CmdQueryParams())
-
-	cmd.AddCommand(CmdGetMintRequests())
-
-	cmd.AddCommand(CmdGetReissuance())
-
-	cmd.AddCommand(CmdGetReissuances())
-
-	cmd.AddCommand(CmdGetChallenge())
-
-	cmd.AddCommand(CmdChallenges())
-
-	cmd.AddCommand(CmdGetDistribution())
-
-	cmd.AddCommand(CmdListRedeemClaim())
-	cmd.AddCommand(CmdShowRedeemClaim())
-	cmd.AddCommand(CmdRedeemClaimByLiquidTxHash())
+	cmd.AddCommand(
+		GetCmdChallenge(),
+		GetCmdChallenges(),
+		GetCmdDistribution(),
+		GetCmdListRedeemClaim(),
+		GetCmdMintRequests(),
+		GetCmdQueryParams(),
+		GetCmdRedeemClaimByLiquidTxHash(),
+		GetCmdReissuance(),
+		GetCmdReissuances(),
+		GetCmdShowRedeemClaim(),
+	)
 
 	// this line is used by starport scaffolding # 1
 

--- a/x/dao/client/cli/query_challenge.go
+++ b/x/dao/client/cli/query_challenge.go
@@ -12,7 +12,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetChallenge() *cobra.Command {
+func GetCmdChallenge() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "challenge [height]",
 		Short: "Query for challenge by height",

--- a/x/dao/client/cli/query_challenges.go
+++ b/x/dao/client/cli/query_challenges.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdChallenges() *cobra.Command {
+func GetCmdChallenges() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "challenges",
 		Short: "Query for challenges",

--- a/x/dao/client/cli/query_distribution.go
+++ b/x/dao/client/cli/query_distribution.go
@@ -14,7 +14,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetDistribution() *cobra.Command {
+func GetCmdDistribution() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "distribution [height]",
 		Short: "Query for distributions by height",

--- a/x/dao/client/cli/query_mint_requests.go
+++ b/x/dao/client/cli/query_mint_requests.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetMintRequests() *cobra.Command {
+func GetCmdMintRequests() *cobra.Command {
 	// Group mint-requests queries under a subcommand
 	cmd := &cobra.Command{
 		Use:                        "mint-requests",

--- a/x/dao/client/cli/query_params.go
+++ b/x/dao/client/cli/query_params.go
@@ -8,7 +8,7 @@ import (
 	"github.com/planetmint/planetmint-go/x/dao/types"
 )
 
-func CmdQueryParams() *cobra.Command {
+func GetCmdQueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Short: "Query the current dao parameters information",

--- a/x/dao/client/cli/query_redeem_claim.go
+++ b/x/dao/client/cli/query_redeem_claim.go
@@ -10,7 +10,7 @@ import (
 	"github.com/planetmint/planetmint-go/x/dao/types"
 )
 
-func CmdListRedeemClaim() *cobra.Command {
+func GetCmdListRedeemClaim() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list-redeem-claim",
 		Short: "list all redeem-claim",
@@ -46,7 +46,7 @@ func CmdListRedeemClaim() *cobra.Command {
 	return cmd
 }
 
-func CmdShowRedeemClaim() *cobra.Command {
+func GetCmdShowRedeemClaim() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "show-redeem-claim [beneficiary] [id]",
 		Short: "shows a redeem-claim",
@@ -86,7 +86,7 @@ func CmdShowRedeemClaim() *cobra.Command {
 
 var _ = strconv.Itoa(0)
 
-func CmdRedeemClaimByLiquidTxHash() *cobra.Command {
+func GetCmdRedeemClaimByLiquidTxHash() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "redeem-claim-by-liquid-tx-hash [liquid-tx-hash]",
 		Short: "Query redeem-claim-by-liquid-tx-hash",

--- a/x/dao/client/cli/query_reissuance.go
+++ b/x/dao/client/cli/query_reissuance.go
@@ -12,7 +12,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetReissuance() *cobra.Command {
+func GetCmdReissuance() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reissuance [height]",
 		Short: "Query for reissuance by height",

--- a/x/dao/client/cli/query_reissuances.go
+++ b/x/dao/client/cli/query_reissuances.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetReissuances() *cobra.Command {
+func GetCmdReissuances() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reissuances",
 		Short: "Query for reissuances",

--- a/x/machine/client/cli/query.go
+++ b/x/machine/client/cli/query.go
@@ -24,16 +24,15 @@ func GetQueryCmd(_ string) *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	cmd.AddCommand(CmdQueryParams())
-	cmd.AddCommand(CmdGetMachineByPublicKey())
-
-	cmd.AddCommand(CmdGetTrustAnchor())
-	cmd.AddCommand(CmdGetMachineByAddress())
-
-	cmd.AddCommand(CmdGetLiquidAssetsByMachineid())
-
-	cmd.AddCommand(CmdActiveTrustAnchorCount())
-	cmd.AddCommand(CmdActivatedTrustAnchorCount())
+	cmd.AddCommand(
+		GetCmdActivatedTrustAnchorCount(),
+		GetCmdActiveTrustAnchorCount(),
+		GetCmdLiquidAssetsByMachineid(),
+		GetCmdMachineByAddress(),
+		GetCmdMachineByPublicKey(),
+		GetCmdQueryParams(),
+		GetCmdTrustAnchor(),
+	)
 
 	// this line is used by starport scaffolding # 1
 

--- a/x/machine/client/cli/query_activated_trust_anchor_count.go
+++ b/x/machine/client/cli/query_activated_trust_anchor_count.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdActivatedTrustAnchorCount() *cobra.Command {
+func GetCmdActivatedTrustAnchorCount() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "activated-trust-anchor-count",
 		Short: "Query activated-trust-anchor-count",

--- a/x/machine/client/cli/query_active_trust_anchor_count.go
+++ b/x/machine/client/cli/query_active_trust_anchor_count.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdActiveTrustAnchorCount() *cobra.Command {
+func GetCmdActiveTrustAnchorCount() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "active-trust-anchor-count",
 		Short: "Query active-trust-anchor-count",

--- a/x/machine/client/cli/query_address.go
+++ b/x/machine/client/cli/query_address.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetMachineByAddress() *cobra.Command {
+func GetCmdMachineByAddress() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "address [address]",
 		Short: "Query for machines by address",

--- a/x/machine/client/cli/query_liquid_assets.go
+++ b/x/machine/client/cli/query_liquid_assets.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetLiquidAssetsByMachineid() *cobra.Command {
+func GetCmdLiquidAssetsByMachineid() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "liquid-assets [machine-id]",
 		Short: "Query for liquid assets by machine ID",

--- a/x/machine/client/cli/query_params.go
+++ b/x/machine/client/cli/query_params.go
@@ -8,7 +8,7 @@ import (
 	"github.com/planetmint/planetmint-go/x/machine/types"
 )
 
-func CmdQueryParams() *cobra.Command {
+func GetCmdQueryParams() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "params",
 		Short: "Query the current machine parameters information",

--- a/x/machine/client/cli/query_public_key.go
+++ b/x/machine/client/cli/query_public_key.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetMachineByPublicKey() *cobra.Command {
+func GetCmdMachineByPublicKey() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "public-key [public-key]",
 		Short: "Query for machines by public key",

--- a/x/machine/client/cli/query_trust_anchor.go
+++ b/x/machine/client/cli/query_trust_anchor.go
@@ -11,7 +11,7 @@ import (
 
 var _ = strconv.Itoa(0)
 
-func CmdGetTrustAnchor() *cobra.Command {
+func GetCmdTrustAnchor() *cobra.Command {
 	// Group trust-anchor queries under a subcommand
 	cmd := &cobra.Command{
 		Use:                        "trust-anchor",


### PR DESCRIPTION
- use one `cmd.AddCommand(...)`
- sort commands
- use `GetCmd...` function name style