### PR TITLE
fix(query): unknown flag: --page

### DIFF
--- a/x/asset/client/cli/query_address.go
+++ b/x/asset/client/cli/query_address.go
@@ -52,6 +52,7 @@ func GetCmdByAddress() *cobra.Command {
 		},
 	}
 
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd

--- a/x/dao/client/cli/query_challenges.go
+++ b/x/dao/client/cli/query_challenges.go
@@ -41,6 +41,7 @@ func GetCmdChallenges() *cobra.Command {
 		},
 	}
 
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd

--- a/x/dao/client/cli/query_reissuances.go
+++ b/x/dao/client/cli/query_reissuances.go
@@ -41,6 +41,7 @@ func GetCmdReissuances() *cobra.Command {
 		},
 	}
 
+	flags.AddPaginationFlagsToCmd(cmd, cmd.Use)
 	flags.AddQueryFlagsToCmd(cmd)
 
 	return cmd


### PR DESCRIPTION
some query commands use pagination when delivering results:
```
pageReq, err := client.ReadPageRequest(cmd.Flags())
if err != nil {
    return err
}
```
to be able to use this feature, we need to add pagination related flags to the `cmd`.