### PR TITLE
refactor(mqtt): defer unlock where applicable

### DIFF
--- a/monitor/backend.go
+++ b/monitor/backend.go
@@ -31,8 +31,8 @@ func (mms *MqttMonitor) AddParticipant(address string, lastSeenTS int64) (err er
 		mms.setNumDBElements(mms.getNumDBElements() + 1)
 	}
 	mms.dbMutex.Lock()
+	defer mms.dbMutex.Unlock()
 	err = mms.db.Put([]byte(address), lastSeenBytes, nil)
-	mms.dbMutex.Unlock()
 	if err != nil {
 		Log("error storing addresses in DB: " + err.Error())
 	} else {
@@ -45,9 +45,8 @@ func (mms *MqttMonitor) AddParticipant(address string, lastSeenTS int64) (err er
 func (mms *MqttMonitor) deleteEntry(key []byte) (err error) {
 	mms.setNumDBElements(mms.getNumDBElements() - 1)
 	mms.dbMutex.Lock()
-	err = mms.db.Delete(key, nil)
-	mms.dbMutex.Unlock()
-	return
+	defer mms.dbMutex.Unlock()
+	return mms.db.Delete(key, nil)
 }
 
 func (mms *MqttMonitor) getAmountOfElements() (amount int64, err error) {

--- a/monitor/interface.go
+++ b/monitor/interface.go
@@ -21,8 +21,8 @@ var mqttMonitorInstance MQTTMonitorClientI
 
 func SetMqttMonitorInstance(monitorInstance MQTTMonitorClientI) {
 	monitorMutex.Lock()
+	defer monitorMutex.Unlock()
 	mqttMonitorInstance = monitorInstance
-	monitorMutex.Unlock()
 }
 
 func GetMqttMonitorInstance() (monitorInstance MQTTMonitorClientI) {
@@ -54,9 +54,8 @@ func LazyMqttMonitorLoader(logger log.Logger, homeDir string) {
 
 func SelectPoPParticipantsOutOfActiveActors() (challenger string, challengee string, err error) {
 	monitorMutex.RLock()
-	challenger, challengee, err = mqttMonitorInstance.SelectPoPParticipantsOutOfActiveActors()
-	monitorMutex.RUnlock()
-	return
+	defer monitorMutex.RUnlock()
+	return mqttMonitorInstance.SelectPoPParticipantsOutOfActiveActors()
 }
 
 func Start() (err error) {
@@ -66,9 +65,8 @@ func Start() (err error) {
 
 func AddParticipant(address string, lastSeenTS int64) (err error) {
 	monitorMutex.RLock()
-	err = mqttMonitorInstance.AddParticipant(address, lastSeenTS)
-	monitorMutex.RUnlock()
-	return
+	defer monitorMutex.RUnlock()
+	return mqttMonitorInstance.AddParticipant(address, lastSeenTS)
 }
 
 func GetActiveActorCount() (count uint64) {

--- a/monitor/mqtt_monitor.go
+++ b/monitor/mqtt_monitor.go
@@ -40,15 +40,14 @@ type MqttMonitor struct {
 
 func (mms *MqttMonitor) Terminate() {
 	mms.terminationMutex.Lock()
+	defer mms.terminationMutex.Unlock()
 	mms.isTerminated = true
-	mms.terminationMutex.Unlock()
 }
 
 func (mms *MqttMonitor) IsTerminated() (isTerminated bool) {
 	mms.terminationMutex.RLock()
-	isTerminated = mms.isTerminated
-	mms.terminationMutex.RUnlock()
-	return
+	defer mms.terminationMutex.RUnlock()
+	return mms.isTerminated
 }
 
 func (mms *MqttMonitor) getNumDBElements() int64 {


### PR DESCRIPTION
also directly return values instead of assigning them first.